### PR TITLE
feat(commands): drive tree selection client-side via list+pick

### DIFF
--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -21,19 +21,34 @@ When a user's question is vague or exploratory, run a lightweight analysis and s
 
 ## Workflow
 
-### Step 1: Investigate
+### Step 1: Pick a tree, then investigate
 
-Always start with the bundled investigation command. Pipe through `tee` to auto-save visualization data.
+The qluent server is deterministic and does NOT match natural-language questions to trees. You must pick the tree client-side before calling `investigate`.
 
-```bash
-qluent trees investigate --question "<user's question>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
-```
-
-Or with a specific tree:
+If the user named a tree explicitly (e.g. "investigate revenue"), use that id directly:
 
 ```bash
 qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
 ```
+
+Otherwise, list the available trees and pick the best fit:
+
+```bash
+qluent trees list --json-output
+```
+
+Read each tree's `id`, `label`, `description`, declared `dimensions`, and child node labels. Match the user's question against this metadata:
+
+- nouns/verbs in the question matching a tree label or child node label,
+- dimensions named in the question (e.g. "by country") matching declared dimensions.
+
+If no tree is a clear winner, ask the user to disambiguate with the top 2–3 candidates. Then run:
+
+```bash
+qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
+```
+
+Always pipe through `tee` to auto-save visualization data.
 
 ### Step 2: Parse and decide
 
@@ -85,6 +100,7 @@ Combine all evidence into a single answer:
 
 ## Rules
 
+- Always pick a tree id client-side via `qluent trees list --json-output` and pass it explicitly to `investigate`.
 - Always use `--json-output` for all qluent commands.
 - Prefer the embedded `investigate.levers` block before rerunning commands for impact questions.
 - Follow `agent.recommended_next_steps` before inventing your own drill-down.

--- a/plugins/qluent/commands/compare.md
+++ b/plugins/qluent/commands/compare.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
 
+If `$ARGUMENTS` looks like a question rather than two tree ids, run `qluent trees list --json-output`, pick the two most relevant trees from the list (match against tree label, child node labels, and declared dimensions), and re-run with those tree ids.
+
 Run a side-by-side comparison of two trees for the same period.
 
 For natural-language periods:

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -1,42 +1,62 @@
 ---
 description: Investigate metric, KPI, or business performance changes (revenue, cost, conversion, sales, ROAS) using deterministic analysis
-argument-hint: "[question or tree-name] [--period 'last week' | --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+argument-hint: "[question or tree-id] [--period 'last week' | --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD]"
+allowed-tools: Bash(qluent *), Read
 ---
 
 # Investigate KPI movement
 
 This is the primary entry point for all metric analysis. It bundles validation, trend, evaluation, and root cause analysis into a single call.
 
-## Step 1: Run the investigation
+The qluent server is deterministic — it does NOT match natural-language questions to trees. YOU pick which tree to analyze when the user asks a question, by listing trees and matching against their metadata.
+
+## Step 1: Decide whether `$ARGUMENTS` is a tree id or a question
+
+If `$ARGUMENTS` is empty, ends with `?`, contains spaces, or contains words like `why`, `what`, `how`, `drove`, `drop`, `spike`, treat it as a **question** and go to Step 2.
+
+If `$ARGUMENTS` is a single token (e.g. `revenue`, `order_volume`, `roas`), treat it as a **tree id** and skip to Step 3.
+
+## Step 2: List the available trees and pick the best fit
+
+Run:
+
+```bash
+qluent trees list --json-output
+```
+
+Read each tree's `id`, `label`, `description`, declared `dimensions`, and the labels of its child nodes. Match the user's question against this metadata. Bias toward:
+
+- nouns in the question that match a tree label (e.g. "revenue" → revenue tree)
+- verbs/concepts that match a child node label (e.g. "spend efficiency" → a roas-style node)
+- dimensions named in the question (e.g. "by country" → tree that declares `country`)
+
+If no tree is a clear winner, ask the user with `AskUserQuestion`, listing the top 2–3 candidates with their labels and descriptions. Do NOT guess silently.
+
+## Step 3: Resolve the time windows
+
+If the user provided `--current` / `--compare`, use those verbatim. Otherwise default to `--period "last week"` (or whatever period phrase the user gave).
+
+## Step 4: Run the bundled investigation with an explicit tree id
 
 Always pipe qluent output through `tee` to save visualization data. This makes `/qluent:visualize` immediately available.
 
-If the user asked a natural-language question:
-
 ```bash
-qluent trees investigate --question "$ARGUMENTS" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
+qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
 ```
 
-If the user named a specific tree and/or date windows, construct the command explicitly:
+For explicit date ranges:
 
 ```bash
 qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output 2>&1 | tee /tmp/qluent-viz-data.json
 ```
 
-For natural-language periods:
-
-```bash
-qluent trees investigate <tree_id> --period "last week" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
-```
-
-## Step 2: Follow server recommendations
+## Step 5: Follow server recommendations
 
 The response includes an `agent` section with `status`, `top_findings`, `gaps`, and `recommended_next_steps`. The `levers` section contains embedded elasticity/lever data when available. Follow the server's recommendations to determine what to do next — run the suggested follow-up commands before inventing your own.
 
 For complex cases, the server may recommend launching specialized agents (`trend-interpreter`, `rca-validator`, `segment-explorer`) in parallel.
 
-## Step 3: Summarize and suggest next steps
+## Step 6: Summarize and suggest next steps
 
 If the user is asking about elasticity, leverage, scenario impact, or "what if":
 
@@ -63,10 +83,11 @@ If the user asks for a segment or breakdown that the current tree does not suppo
 
 ## Rules
 
-- Always use `--json-output` when driving the workflow
-- Prefer the embedded `levers` block before rerunning commands for impact questions
-- For full-year date ranges, if RCA times out, suggest quarterly breakdowns
-- If the user asks a follow-up, check if the existing data answers it before re-running
-- Never parse tool-result temp files or write ad-hoc scripts against prior bash output
-- Do not rerun both JSON and non-JSON versions of the same qluent command unless JSON is genuinely insufficient
-- If the requested cut is unsupported on the current tree, pivot to the closest compatible tree rather than handing control back
+- Always pass an explicit `<tree_id>` to `investigate`, chosen client-side via Step 2 (`qluent trees list --json-output`).
+- Always use `--json-output` when driving the workflow.
+- Prefer the embedded `levers` block before rerunning commands for impact questions.
+- For full-year date ranges, if RCA times out, suggest quarterly breakdowns.
+- If the user asks a follow-up, check if the existing data answers it before re-running.
+- Never parse tool-result temp files or write ad-hoc scripts against prior bash output.
+- Do not rerun both JSON and non-JSON versions of the same qluent command unless JSON is genuinely insufficient.
+- If the requested cut is unsupported on the current tree, pivot to the closest compatible tree rather than handing control back.

--- a/plugins/qluent/commands/rca.md
+++ b/plugins/qluent/commands/rca.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
 
+If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id.
+
 ## Step 1: Run deterministic RCA
 
 For natural-language periods:

--- a/plugins/qluent/commands/trend.md
+++ b/plugins/qluent/commands/trend.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
 
+If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id.
+
 Parse the arguments from `$ARGUMENTS` and run:
 
 ```bash


### PR DESCRIPTION
## Summary

- Rewrites \`/qluent:investigate\` so the model picks a tree client-side: detect question vs. tree-id in \`\$ARGUMENTS\`, run \`qluent trees list --json-output\`, match the question against tree labels, child node labels, and declared dimensions, and only then call \`qluent trees investigate <tree_id> ...\`. Falls back to \`AskUserQuestion\` on ambiguity.
- Updates the \`qluent-analyst\` agent so Step 1 lists trees first when the user gives a natural-language question.
- Adds a brief list-first preamble to \`/qluent:trend\`, \`/qluent:rca\`, and \`/qluent:compare\` for cases where users pass a question by mistake.

## Why

The qluent server is deterministic and no longer matches natural-language questions to trees. The companion qluent-cli PR removes \`qluent trees match\` and \`qluent trees investigate --question ...\`, both of which currently 404.

## Test plan

- [ ] \`/qluent:investigate Why did revenue drop last week?\` — Claude calls \`qluent trees list --json-output\` first, then \`qluent trees investigate <tree_id> ...\` with no \`--question\` flag.
- [ ] \`/qluent:investigate revenue --period "last week"\` — Claude skips the list step and runs directly on the named tree.
- [ ] Ambiguous question (e.g. "tell me about performance") — Claude asks via \`AskUserQuestion\` rather than guessing silently.

## Companion PR

Pairs with the qluent-cli PR that removes the now-dead \`match\` command and \`--question\` flag.