### PR TITLE
[codex] Add elasticity interpretation guardrails

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -45,6 +45,9 @@ For elasticity, leverage, impact, scenario, or "what if" follow-ups:
 - Read the structured `investigate` JSON first, especially `levers`, `evaluation`, and `agent.recommended_next_steps`
 - Reuse the exact current/comparison windows from the last investigation
 - If the embedded `levers` block is not enough, run `qluent trees levers <tree_id> --current <same>:<same> --compare <same>:<same> --json-output`
+- Label elasticity evidence as directional sensitivity unless the response explicitly supports causal language
+- Recommend lever changes only when materiality, confidence/evidence coverage, and guardrail metrics are sufficient in the returned result
+- When evidence is weak, suggest the next drill, comparison, or validation test instead of an action plan
 - Never parse tool-result temp files or write ad-hoc scripts against prior bash output
 - Do not rerun both JSON and non-JSON versions of the same qluent command unless JSON is genuinely insufficient
 

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -50,6 +50,7 @@ If the user is asking about elasticity, leverage, scenario impact, or "what if":
    qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
    ```
 4. **Treat the result correctly**: lever impacts are local linear estimates based on current elasticities, not forecasts.
+5. **Apply elasticity guardrails**: label the evidence type, report materiality/confidence/guardrail warnings, and turn weak or incomplete evidence into the next drill or validation test instead of an action recommendation.
 
 If the user asks for a segment or breakdown that the current tree does not support:
 
@@ -87,6 +88,7 @@ Combine all evidence into a single answer:
 
 - Always use `--json-output` for all qluent commands.
 - Prefer the embedded `investigate.levers` block before rerunning commands for impact questions.
+- For elasticity or lever answers, recommendations require sufficient materiality, evidence coverage, and clean guardrail metrics from the returned result.
 - Follow `agent.recommended_next_steps` before inventing your own drill-down.
 - If RCA times out on large date ranges, suggest quarterly breakdowns.
 - Do not speculate beyond what the data shows. If the evidence is partial, say so.

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -14,4 +14,38 @@ Key principles:
 - Trend labels, anomaly flags, and mechanism interpretations are included in the server response.
 - When a `levers` block is available, lever impacts are local linear estimates from the current operating point, not forecasts.
 
+## Elasticity and lever guardrails
+
+Elasticity output is directional decision support, not causal proof. Treat it as a measured association from the returned sample window unless the server response explicitly includes causal validation.
+
+When interpreting `levers`, `elasticity`, scenario, or impact fields:
+
+- Label the evidence type: elasticity estimate, Shapley attribution, trend corroboration, segment concentration, or server-provided causal validation.
+- State the exact sample windows used and the dimensions or cuts included in the returned result.
+- Report the server-provided confidence, materiality, data-quality warnings, and guardrail metrics before recommending any lever change.
+- Distinguish correlation and sensitivity from causality. Do not write that a lever "caused" root KPI movement unless a returned field explicitly supports causal language.
+- Treat low confidence, immaterial effects, sparse windows, volatile segments, or guardrail warnings as reasons to suggest the next drill or test, not an action plan.
+- For scenario rows such as +1%, +5%, or +10%, say they are local linear estimates from the current operating point and may not hold outside the observed range.
+
+Recommendations require all of these conditions:
+
+- The lever effect is material in the returned result, not just directionally interesting.
+- Confidence or evidence coverage is sufficient according to the server response.
+- Guardrail metrics do not show an offsetting risk or unresolved data-quality warning.
+- The recommendation is scoped to the returned sample window and segment/dimension context.
+
+If those conditions are not met, recommend the next best drill instead. Examples include extending the window, validating the same lever across another segment, running `/qluent:compare`, or asking for an experiment/instrumentation check.
+
+Acceptable phrasing:
+
+- "The returned elasticity table shows a directional association: in 2026-04-13:2026-04-19 vs 2026-04-06:2026-04-12, conversion rate has the largest local sensitivity, with sufficient evidence coverage and no guardrail warning. Treat the +5% row as a local estimate, not a forecast."
+- "This is weak evidence for action. The lever is directionally positive, but the returned confidence is low and the segment sample is sparse, so the next step is to drill by channel before changing spend."
+- "The RCA attributes most of the movement to average order value, while the elasticity estimate says conversion rate is the larger local lever. That is a mechanism hypothesis, not proof that changing conversion caused the prior movement."
+
+Unacceptable phrasing:
+
+- "Increase conversion by 5% and revenue will rise by the scenario amount."
+- "The elasticity proves conversion caused the revenue drop."
+- "This lever is the best action" when confidence, materiality, guardrails, or sample windows are missing.
+
 Refer to the server response fields for all interpretation details.


### PR DESCRIPTION
## Summary
- Add explicit elasticity and lever interpretation guardrails to the shared qluent interpretation skill.
- Require evidence type labeling, windows/dimension context, materiality, confidence/evidence coverage, and guardrail checks before action recommendations.
- Add acceptable and unacceptable phrasing examples, and wire the guardrails into Claude/plugin analyst instructions.

## Validation
- Ran git diff --check.

Closes #10