### PR TITLE
[codex] Add RCA next-best drill workflow

### DIFF
--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -41,6 +41,16 @@ Read the JSON response. The `agent` section contains `status`, `top_findings`, `
 
 ### Step 3: Follow up autonomously
 
+For RCA-style "why did this move?" questions:
+
+1. Start from the mapped root metric and the exact windows used by `/qluent:investigate`.
+2. Inspect root movement first, then use returned RCA fields to decompose child drivers.
+3. Rank drivers by returned materiality, attribution, and confidence/evidence coverage.
+4. Drill only the material branches that can change the answer. Avoid exhaustive low-value probing of every child node.
+5. Segment material drivers when dimensions are available; if the requested cut is unsupported, pivot to the closest compatible companion tree and keep the same windows.
+6. Separate mix effects from behavior/rate effects when the returned tree structure or comparison output supports that distinction.
+7. End with ranked next-best drills. Weak or incomplete evidence should become a drill, validation, or comparison suggestion, not an action recommendation.
+
 If the user is asking about elasticity, leverage, scenario impact, or "what if":
 
 1. **Check `levers` first.** If the embedded lever summary already answers the question, use it directly.
@@ -88,6 +98,8 @@ Combine all evidence into a single answer:
 - Always use `--json-output` for all qluent commands.
 - Prefer the embedded `investigate.levers` block before rerunning commands for impact questions.
 - Follow `agent.recommended_next_steps` before inventing your own drill-down.
+- Prefer material, confidence-supported branches for RCA follow-up; do not drill every branch just because data exists.
+- Recommendations require sufficient materiality and confidence. Otherwise, recommend the next best drill or validation test.
 - If RCA times out on large date ranges, suggest quarterly breakdowns.
 - Do not speculate beyond what the data shows. If the evidence is partial, say so.
 - Report numbers from the qluent output — do not round or estimate.

--- a/plugins/qluent/agents/rca-validator.md
+++ b/plugins/qluent/agents/rca-validator.md
@@ -16,11 +16,17 @@ Given RCA output (passed as context or run fresh), validate each top finding by 
 
 For each finding in the RCA output:
 
-1. **Cross-reference with trend**: Run `qluent trees trend` to verify the movement is consistent across periods (not a one-off data artifact).
+1. **Rank materiality first**: Validate the largest returned contributors before lower-impact findings. Skip exhaustive validation of immaterial branches unless a warning or anomaly makes them decision-relevant.
 
-2. **Validate mechanism**: Check whether the flagged driver's sub-metrics tell a coherent story. Use `qluent trees evaluate` on the relevant subtree if needed.
+2. **Cross-reference with trend**: Run `qluent trees trend` to verify the movement is consistent across periods (not a one-off data artifact).
 
-3. **Use server-provided interpretations**: The RCA response includes confidence scores, evidence breakdowns, and interpretation labels. Report these to the user along with your cross-reference findings.
+3. **Validate mechanism**: Check whether the flagged driver's sub-metrics tell a coherent story. Use `qluent trees evaluate` on the relevant subtree if needed.
+
+4. **Separate mix from behavior**: When a driver can be explained by composition shift versus rate/behavior change, call that out and recommend the deterministic query that would distinguish them.
+
+5. **Use server-provided interpretations**: The RCA response includes confidence scores, evidence breakdowns, and interpretation labels. Report these to the user along with your cross-reference findings.
+
+6. **Choose next-best drills**: If evidence is partial, rank the next 2-3 drills by expected value: materiality first, then confidence gap, then available dimensions.
 
 ## Output format
 
@@ -28,5 +34,6 @@ For each finding, return:
 - **Finding**: the original claim
 - **Validation**: confirmed / partially confirmed / unconfirmed
 - **Evidence**: what corroborates or contradicts it
+- **Next-best drill**: the highest-value deterministic follow-up if the finding remains uncertain
 
 Be skeptical. False positives erode trust.

--- a/plugins/qluent/commands/rca.md
+++ b/plugins/qluent/commands/rca.md
@@ -9,7 +9,13 @@ disable-model-invocation: true
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
 
-## Step 1: Run deterministic RCA
+If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id. If no tree is a clear fit, ask the user to choose from the top candidates.
+
+## Step 1: Resolve tree and window deterministically
+
+Use the tree id and exact current/comparison windows from the prior `/qluent:investigate` result when available. If the user supplied a new period or explicit windows, use those verbatim. Do not infer quantitative movement without fresh qluent JSON for the chosen tree/window.
+
+## Step 2: Run deterministic RCA
 
 For natural-language periods:
 
@@ -23,11 +29,36 @@ For explicit date windows:
 qluent rca analyze <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output
 ```
 
-## Step 2: Report the results
+## Step 3: Rank material drivers
+
+Use only returned RCA fields to rank drivers. Prefer branches that are both material and supported by confidence/evidence fields. Do not exhaustively drill low-contribution branches unless the server response flags them as anomalous or strategically important.
+
+For each top driver, capture:
+
+- contribution share or attribution value
+- absolute delta when returned
+- confidence/evidence coverage
+- warnings, gaps, or data-quality flags
+- child nodes or dimensions available for a follow-up drill
+
+## Step 4: Choose next-best drills
+
+Turn the ranked drivers into 2-3 concrete next-best drills. Prefer:
+
+- segmenting the most material supported driver by available dimensions
+- checking mix vs behavior when the movement could be composition-driven
+- running `/qluent:compare` when mechanism validation across trees would reduce uncertainty
+- extending or splitting the time window when confidence is low or the movement is volatile
+
+Weak, low-confidence, or immaterial results should produce validation/drill suggestions, not action recommendations.
+
+## Step 5: Report the results
 
 The response includes pre-computed conclusions, attribution shares, confidence scores, and interpretation labels. Present these to the user:
 
 - Lead with the root cause and supporting evidence
 - List the top contributing nodes with their attribution shares
 - Note any gaps or warnings from the server response
-- Suggest `/qluent:compare` if mechanism validation would help
+- State the exact current and comparison windows
+- Include caveats when materiality or confidence is insufficient
+- End with ranked next-best drills and why each one is next


### PR DESCRIPTION
## Summary
- Expand /qluent:rca into a deterministic RCA workflow that resolves tree/window context, ranks material drivers, and chooses next-best drills.
- Update the qluent analyst to prefer material, confidence-supported branches instead of exhaustive probing.
- Update RCA validation output to include next-best drill suggestions when evidence remains uncertain.

## Validation
- Ran git diff --check.

Closes #11