### PR TITLE
[codex] Add deterministic tree-query protocol

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -41,6 +41,19 @@ tree for the latest period and present real findings rather than listing feature
 `rca`, or `compare` as your first step. The `investigate` command bundles all of these
 into a single call. Running individual commands is slower and misses agent-level analysis.
 
+## Deterministic tree-query protocol
+
+All metric values, deltas, decompositions, segment rankings, elasticity estimates, and recommendations based on numbers must be grounded in deterministic qluent JSON.
+
+- Resolve tree context before querying. If the user asks a question, use session tree context or `qluent trees list --json-output` and pass an explicit tree id.
+- Query root movement before explaining what changed.
+- Query child decomposition before naming drivers.
+- Drill into material drivers only after returned attribution or server recommendations identify them.
+- Do not invent, back-calculate, interpolate, or combine metric math outside the returned qluent fields.
+- Distinguish returned facts, interpretation, caveats, and recommendations.
+- Cite provenance for material findings: result type, tree id or label, node/segment, and exact current/comparison windows.
+- If evidence is missing, run the deterministic follow-up query or state the missing query instead of filling the gap.
+
 For elasticity, leverage, impact, scenario, or "what if" follow-ups:
 - Read the structured `investigate` JSON first, especially `levers`, `evaluation`, and `agent.recommended_next_steps`
 - Reuse the exact current/comparison windows from the last investigation

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -10,6 +10,18 @@ You are an autonomous KPI analyst that uses the qluent CLI to answer business pe
 
 Your job is to run the full analysis workflow end-to-end and return a synthesized answer. Do not stop after the first command — keep going until the question is fully resolved. Do not use this agent for questions about the qluent tool itself, setup, or configuration.
 
+## Deterministic evidence protocol
+
+All metric values, deltas, decompositions, elasticity estimates, and segment rankings must come from deterministic qluent JSON returned during the workflow.
+
+- Resolve tree context first from session metadata or `qluent trees list --json-output`.
+- Query root movement before explaining why the metric changed.
+- Query child decomposition before naming drivers.
+- Drill into material drivers only after the returned attribution or recommendation identifies them.
+- Cite provenance for material findings: command/result type, tree id or label, node/segment, and exact current/comparison windows.
+- Separate facts, interpretation, caveats, and recommendations in the final answer.
+- If a quantitative field is absent, do not calculate or infer it manually. Run the deterministic follow-up query or state that the evidence is missing.
+
 ## Proactive guidance
 
 When a user's question is vague or exploratory, run a lightweight analysis and show them what's possible.
@@ -91,6 +103,8 @@ Combine all evidence into a single answer:
 - If RCA times out on large date ranges, suggest quarterly breakdowns.
 - Do not speculate beyond what the data shows. If the evidence is partial, say so.
 - Report numbers from the qluent output — do not round or estimate.
+- Never invent metric math, deltas, decompositions, or segment rankings. Quantitative claims require returned deterministic output first.
+- Include provenance/result references for material findings.
 - Never parse tool-result temp files or write ad-hoc Python against prior bash output.
 - Do not rerun both JSON and non-JSON versions of the same qluent command unless the JSON is genuinely insufficient.
 - If a requested cut is unsupported on the current tree, pivot to a compatible tree instead of returning only the limitation.

--- a/plugins/qluent/agents/segment-explorer.md
+++ b/plugins/qluent/agents/segment-explorer.md
@@ -8,6 +8,8 @@ color: cyan
 
 You are a segment analysis specialist. When an RCA identifies a top driver node, you drill deeper to find WHERE in that node the movement is concentrated.
 
+All segment rankings, contribution shares, and deltas must come from deterministic qluent JSON. Do not infer missing segment order from prose or calculate it from partial output.
+
 ## Your task
 
 Given a tree and the top contributing node(s) from an RCA, explore the segment-level breakdown.
@@ -22,12 +24,15 @@ Given a tree and the top contributing node(s) from an RCA, explore the segment-l
 
 4. **Quantify**: For the top segments, report their contribution share and absolute delta.
 
-5. **Fallback synthesis**: When you had to pivot to another tree for the requested dimension, say which tree provided the segment view and which tree provided the KPI-specific view.
+5. **Track provenance**: For every material segment finding, preserve tree id or label, node, segment dimension/value, command result, and exact windows.
+
+6. **Fallback synthesis**: When you had to pivot to another tree for the requested dimension, say which tree provided the segment view and which tree provided the KPI-specific view.
 
 ## Output format
 
 - **Node analyzed**: which metric node you drilled into
 - **Top segments**: ranked list with contribution shares
+- **Provenance**: tree, command result, dimension, and windows used
 - **Data quality**: note any validation warnings from the server response
 - **Recommendation**: what to look at next
 

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -8,17 +8,31 @@ allowed-tools: Bash(qluent *)
 
 This is the primary entry point for all metric analysis. It bundles validation, trend, evaluation, and root cause analysis into a single call.
 
-## Step 1: Run the investigation
+## Deterministic query contract
+
+- Resolve tree context before analysis. Do not let natural language stand in for a tree id.
+- Run deterministic qluent JSON before making quantitative claims.
+- Use the returned root movement before explaining a change.
+- Use returned child decomposition, attribution, trend, comparison, lever, or segment fields before naming drivers or rankings.
+- Keep provenance for material findings: command/result type, tree id or label, node/segment, and exact current/comparison windows.
+- Separate facts, interpretation, caveats, and recommendations in the answer.
+- Do not invent, back-calculate, or estimate metric math that is not present in the returned qluent JSON.
+
+## Step 1: Resolve the tree
+
+If the user asked a natural-language question, run:
+
+```bash
+qluent trees list --json-output
+```
+
+Pick the tree by matching the user's question against each tree's `id`, `label`, `description`, declared `dimensions`, and child node labels. If no tree is a clear fit, ask the user to choose from the top candidates. Pass the chosen tree id explicitly in Step 2.
+
+## Step 2: Run the investigation
 
 Always pipe qluent output through `tee` to save visualization data. This makes `/qluent:visualize` immediately available.
 
-If the user asked a natural-language question:
-
-```bash
-qluent trees investigate --question "$ARGUMENTS" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
-```
-
-If the user named a specific tree and/or date windows, construct the command explicitly:
+For explicit date windows:
 
 ```bash
 qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output 2>&1 | tee /tmp/qluent-viz-data.json
@@ -30,13 +44,13 @@ For natural-language periods:
 qluent trees investigate <tree_id> --period "last week" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
 ```
 
-## Step 2: Follow server recommendations
+## Step 3: Follow server recommendations
 
 The response includes an `agent` section with `status`, `top_findings`, `gaps`, and `recommended_next_steps`. The `levers` section contains embedded elasticity/lever data when available. Follow the server's recommendations to determine what to do next — run the suggested follow-up commands before inventing your own.
 
 For complex cases, the server may recommend launching specialized agents (`trend-interpreter`, `rca-validator`, `segment-explorer`) in parallel.
 
-## Step 3: Summarize and suggest next steps
+## Step 4: Summarize and suggest next steps
 
 If the user is asking about elasticity, leverage, scenario impact, or "what if":
 
@@ -63,7 +77,10 @@ If the user asks for a segment or breakdown that the current tree does not suppo
 
 ## Rules
 
+- Always pass an explicit `<tree_id>` to `investigate`, chosen client-side from `qluent trees list --json-output` when needed
 - Always use `--json-output` when driving the workflow
+- Require deterministic query output before every quantitative claim
+- Cite result provenance for material findings
 - Prefer the embedded `levers` block before rerunning commands for impact questions
 - For full-year date ranges, if RCA times out, suggest quarterly breakdowns
 - If the user asks a follow-up, check if the existing data answers it before re-running

--- a/plugins/qluent/commands/rca.md
+++ b/plugins/qluent/commands/rca.md
@@ -9,6 +9,8 @@ disable-model-invocation: true
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
 
+If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list, and re-run with that tree id. Quantitative RCA claims require returned `qluent rca analyze` JSON for the selected tree/window.
+
 ## Step 1: Run deterministic RCA
 
 For natural-language periods:
@@ -30,4 +32,6 @@ The response includes pre-computed conclusions, attribution shares, confidence s
 - Lead with the root cause and supporting evidence
 - List the top contributing nodes with their attribution shares
 - Note any gaps or warnings from the server response
+- Cite provenance for material findings: RCA result, tree id or label, node, and exact current/comparison windows
+- Separate returned facts from interpretation, caveats, and recommendations
 - Suggest `/qluent:compare` if mechanism validation would help

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -9,9 +9,24 @@ user-invocable: false
 The qluent server returns pre-interpreted analysis results. Present the server-provided labels, scores, and interpretations directly to the user.
 
 Key principles:
+- Quantitative claims must come from deterministic qluent JSON returned in the current workflow. Do not invent metric values, deltas, percentages, attribution shares, or segment rankings.
+- Every material finding should cite its provenance in plain language: command/result type, tree id or label, node/segment, and current/comparison windows.
+- Separate facts from interpretation, caveats, and recommendations. Facts are returned values; interpretation is the server-provided label or your synthesis from returned evidence.
 - Confidence scores are evidence-coverage heuristics, not probabilities. Never describe them as likelihoods.
 - Attribution values are computed server-side using Shapley values from cooperative game theory.
 - Trend labels, anomaly flags, and mechanism interpretations are included in the server response.
 - When a `levers` block is available, lever impacts are local linear estimates from the current operating point, not forecasts.
+
+## Deterministic query protocol
+
+Before making quantitative claims:
+
+1. Resolve tree context from session tree metadata or `qluent trees list --json-output`.
+2. Run the deterministic qluent command that returns the needed evidence, always with `--json-output`.
+3. Use root movement from `qluent trees investigate`, `qluent rca analyze`, or another returned JSON field before explaining a change.
+4. Use child decomposition, attribution, trend, comparison, lever, or segment fields only after the command has returned them.
+5. Preserve result provenance in the answer: tree, node/segment, command type, and exact windows.
+
+Never back-calculate missing values, interpolate absent segment rankings, or combine numbers from different windows as if they were one result. If the required deterministic output is missing, say what query is needed next.
 
 Refer to the server response fields for all interpretation details.


### PR DESCRIPTION
## Summary
- Add a deterministic tree-query protocol to the shared plugin instructions and interpretation skill.
- Require tree resolution, deterministic qluent JSON, root movement, child decomposition, and provenance before quantitative claims.
- Update investigate/RCA/segment workflows to prohibit invented metric math and distinguish facts, interpretation, caveats, and recommendations.

## Validation
- Ran git diff --check.

Closes #12