### PR TITLE
[codex] Align visualize workflow with RcaReportSpec

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -86,9 +86,28 @@ For unsupported segment cuts or breakdown requests:
 The specialized agents (trend-interpreter, rca-validator, segment-explorer) are launched
 in parallel by the investigate command or qluent-analyst for complex, broad, or low-confidence cases.
 
-## Visualization
+## Visualization and reporting
 
-**Always use `/qluent:visualize` for charts.** Never write custom HTML, CSS, or Chart.js code. The plugin includes a styled dashboard renderer (`render-charts.sh`) with the Qluent design system — custom HTML will look wrong and miss brand styling.
+**Always use `/qluent:visualize` for charts and RCA reports.** When deterministic
+RCA or elasticity JSON is available, shape it into the UI `RcaReportSpec` contract
+first: set `outcomeShape`, populate ordered `sections[]`, and preserve `caveats[]`
+and `sources[]`. Do not hand-roll report HTML when the UI report contract can be used.
+
+Map qluent JSON into report sections consistently:
+- root movement → `root_movement`
+- RCA driver findings and direct contributors → `driver_decomposition`
+- `segment_findings` → `material_segment_scan`
+- `mix_shift` → `mix_shift`
+- elasticity/levers → `elasticity_summary`
+- `agent.recommended_next_steps` → `next_drills`
+
+Preserve deterministic provenance, exact date windows, materiality, caveats, and
+CLI/UI evidence labels: `observed_correlation`, `historical_elasticity`,
+`model_estimate`, and `experiment_backed`.
+
+For quick local demos or basic data, `/qluent:visualize` may still use the styled
+dashboard renderer (`render-charts.sh`) with the Qluent design system. Never write
+custom HTML, CSS, or Chart.js code by hand.
 
 All qluent analysis commands should pipe through `tee` to auto-save visualization data:
 
@@ -102,7 +121,7 @@ This makes `/qluent:visualize` immediately available after any analysis.
 
 This plugin provides purpose-built skills for common workflows. **Always use them instead of improvising.**
 
-- Charts or dashboards → `/qluent:visualize` (never write custom HTML)
+- Charts or RCA reports → `/qluent:visualize` (prefer `RcaReportSpec`; never write custom HTML)
 - Analysis → `/qluent:investigate` (never manually chain CLI commands as a first step)
 - Follow-ups → `/qluent:trend`, `/qluent:rca`, `/qluent:compare`, or `qluent trees levers` (not ad-hoc scripts)
 

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -1,14 +1,15 @@
 ---
-description: Visualize the latest qluent analysis output as interactive HTML charts in the browser
+description: Shape the latest qluent analysis output into a UI report spec, with HTML charts as a local fallback
 argument-hint: "[--file /path/to/json] [--simple]"
 allowed-tools: Bash(*), Read, Write, Glob
 ---
 
 # Visualize qluent output
 
-Generates an insight-driven HTML dashboard from the most recent qluent analysis. The dashboard
-is tailored to the specific findings — the analysis determines which charts appear, not a
-fixed template.
+Shapes the most recent qluent analysis into an outcome-shaped `RcaReportSpec` for the
+Qluent UI. When deterministic RCA or elasticity output is available, the report spec is
+the primary artifact. Use the local HTML renderer only as a fallback for quick demos,
+basic data, or when the UI report contract cannot be consumed.
 
 ## Step 1: Locate and validate the data
 
@@ -19,7 +20,16 @@ that path instead. If the file doesn't exist or is empty, tell the user to run
 **Freshness check:** Read the file and verify `current_window.date_from` is recent. If the
 data looks stale (wrong tree, old dates), warn the user and suggest re-running investigate.
 
-## Step 2: Choose rendering mode
+## Step 2: Choose report mode
+
+**Report spec mode** (default for deterministic RCA/elasticity output): Produce or request
+an outcome-shaped `RcaReportSpec` with `outcomeShape`, ordered `sections[]`, `caveats`,
+and `sources`. Use this when the JSON contains `root_cause`, `evaluation`, `levers`,
+`agent.recommended_next_steps`, `mix_shift`, or segment findings.
+
+Do not hand-roll report HTML when the UI report contract can be used. Preserve the
+deterministic qluent values and provenance in the spec instead of translating findings
+into one-off dashboard markup.
 
 **Simple mode** (`--simple` flag or no investigation context): Use the generic render script
 for a quick chart. This is the fallback for basic data or when the user just wants something fast.
@@ -28,11 +38,80 @@ for a quick chart. This is the fallback for basic data or when the user just wan
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/render-charts.sh" /tmp/qluent-viz-data.json /tmp/qluent-viz.html
 ```
 
-**Insight mode** (default when investigation data is rich): Generate a custom HTML dashboard
-driven by the analysis findings. Use this when the JSON contains `agent.top_findings`,
-`root_cause.conclusion.takeaways`, `mix_shift`, segment data, or cross-tree comparisons.
+**HTML fallback mode** (local demo only): Generate a custom HTML dashboard driven by the
+analysis findings when the user explicitly asks for browser-rendered charts or the UI
+report contract is unavailable. Use this for `/tmp/qluent-viz.html`, not as the primary
+synchronized report artifact.
 
-## Step 3: Generate insight-driven dashboard
+## Step 3: Build an outcome-shaped RcaReportSpec
+
+Read the JSON data and map the deterministic qluent fields into an ordered report spec:
+
+```ts
+{
+  outcomeShape: 'driver_concentration' | 'mix_shift' | 'elasticity_tradeoff' | 'data_quality_blocker' | string,
+  sections: [
+    { type: 'root_movement', data: ... },
+    { type: 'driver_decomposition', data: ... },
+    { type: 'material_segment_scan', data: ... },
+    { type: 'mix_shift', data: ... },
+    { type: 'elasticity_summary', data: ... },
+    { type: 'next_drills', data: ... }
+  ],
+  caveats: [],
+  sources: []
+}
+```
+
+### Outcome shape guidance
+
+Choose `outcomeShape` from the strongest returned evidence:
+
+- `driver_concentration`: Shapley/RCA findings show one or a few direct contributors
+  explain most of the root movement.
+- `mix_shift`: `root_cause.mix_shift` or returned mix effects explain a material part
+  of the movement.
+- `elasticity_tradeoff`: `levers` or elasticity output shows a material sensitivity,
+  tradeoff, guardrail, or scenario estimate.
+- `data_quality_blocker`: qluent returns missing, stale, sparse, or low-confidence
+  evidence that blocks a reliable interpretation.
+- Use a specific string only when the UI contract supports it or the returned qluent
+  payload names an outcome shape.
+
+### Section mapping
+
+Build `sections[]` in the order that best tells the returned story, using only sections
+backed by actual qluent fields:
+
+1. `root_movement`: root metric, current/comparison windows, absolute and percentage
+   movement, tree id/label, and any server-provided period labels.
+2. `driver_decomposition`: RCA driver findings, direct contributors, Shapley effects,
+   materiality, confidence/evidence coverage, and supporting takeaways.
+3. `material_segment_scan`: `root_cause.findings[].segment_findings` and material
+   segment scans by node, dimension, segment value, contribution, and window.
+4. `mix_shift`: `root_cause.mix_shift`, mix/baseline effects, segment mix changes,
+   and returned interpretation.
+5. `elasticity_summary`: `levers`, elasticity coefficients, scenario impacts, guardrail
+   warnings, and actionability limits. Treat elasticity as directional sensitivity unless
+   the returned response explicitly supports stronger causal language.
+6. `next_drills`: `agent.recommended_next_steps`, unresolved gaps, validation drills,
+   comparison suggestions, or tests needed before action.
+
+### Provenance and evidence labels
+
+Every material section must preserve deterministic provenance:
+
+- Include the qluent command/result type, tree id or label, node id/label, segment
+  dimension/value when present, exact current/comparison windows, materiality, and
+  confidence/evidence coverage.
+- Carry caveats from returned `gaps`, low confidence, sparse samples, missing dimensions,
+  unsupported cuts, guardrail warnings, or stale windows into top-level `caveats[]`.
+- Carry result references and data lineage into `sources[]`; do not cite unstated data.
+- Use CLI/UI evidence labels exactly when present: `observed_correlation`,
+  `historical_elasticity`, `model_estimate`, and `experiment_backed`.
+- Separate returned facts from interpretation, caveats, and recommendations.
+
+## Step 4: HTML fallback for local demos
 
 Read the JSON data and determine which sections to include based on what evidence is present.
 Reference the `dashboard-design` skill for the design system (tokens, components, Chart.js
@@ -116,7 +195,7 @@ const segments = finding.segment_findings;
 const levers = data.levers.top_levers;
 ```
 
-## Step 4: Open in browser
+## Step 5: Open fallback HTML in browser
 
 ```bash
 # macOS
@@ -129,6 +208,10 @@ xdg-open /tmp/qluent-viz.html
 ## Rules
 
 - Always read the data file first to verify freshness before rendering
+- Prefer an outcome-shaped `RcaReportSpec` with `outcomeShape` and ordered `sections[]`
+  whenever deterministic RCA or elasticity output is available
+- Do not hand-roll report HTML when the UI report contract can be used
+- Preserve deterministic provenance, caveats, date windows, materiality, and evidence labels
 - Use the `dashboard-design` skill for all design decisions — do not invent new styles
 - Section titles must be insight statements, not generic labels
 - Only include sections backed by actual data — never generate placeholder charts

--- a/plugins/qluent/scripts/post-bash.sh
+++ b/plugins/qluent/scripts/post-bash.sh
@@ -211,7 +211,7 @@ echo "[Qluent] Analysis complete."
 # Viz data reminder
 if [[ "$command" == *"--json-output"* ]]; then
   if [ -f "$viz_file" ]; then
-    echo "  → Visualization data saved. Use /qluent:visualize for styled Qluent charts — do not write custom HTML."
+    echo "  → Visualization data saved. Use /qluent:visualize to produce a UI RcaReportSpec first; use styled HTML only as a local fallback."
   else
     echo "  → To enable /qluent:visualize, pipe output through: | tee /tmp/qluent-viz-data.json"
   fi
@@ -223,9 +223,9 @@ fi
 
 # Contextual follow-up suggestions
 if $is_investigate; then
-  echo "  → Follow-up skills: /qluent:visualize (charts), /qluent:rca (root cause), /qluent:trend (multi-period), /qluent:compare (cross-tree)"
+  echo "  → Follow-up skills: /qluent:visualize (RcaReportSpec/charts), /qluent:rca (root cause), /qluent:trend (multi-period), /qluent:compare (cross-tree)"
 fi
 
 if $is_trend || $is_rca || $is_compare; then
-  echo "  → Offer /qluent:visualize to render these results as styled charts."
+  echo "  → Offer /qluent:visualize to shape these results into RcaReportSpec sections, with styled charts as a fallback."
 fi


### PR DESCRIPTION
## Summary

- Make `/qluent:visualize` prefer an outcome-shaped `RcaReportSpec` when deterministic RCA or elasticity JSON is available.
- Add explicit mapping from qluent JSON fields to ordered report `sections[]`, including root movement, driver decomposition, segment scans, mix shift, elasticity, and next drills.
- Update plugin-level guidance and post-command reminders so HTML rendering remains available only as a quick local fallback.

## Root cause

The visualization workflow still described rich investigations as custom HTML dashboard generation, which could push Claude toward one-off Chart.js reports instead of the synchronized UI report contract.

## Validation

- `bash -n plugins/qluent/scripts/post-bash.sh`
- `git diff --check`

Closes #17
