### PR TITLE
[codex] Improve first-run onboarding and report guidance

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -28,6 +28,23 @@ segment dimensions — use that context to tailor suggestions.
 **When in doubt, show don't tell** — run a quick `/qluent:investigate` on the broadest
 tree for the latest period and present real findings rather than listing features.
 
+**First-run orientation:** after login or plugin reload, orient the user from available
+tree metadata. Name the connected project if the CLI reports it, list the available tree
+ids, summarize what each tree is useful for, and offer one concrete first investigation.
+Use `qluent whoami`, `qluent status`, and `qluent suggestions` only when those commands
+are available. Do not probe made-up commands such as `qluent projects list`; if a command
+is unsupported, fall back to `qluent trees list --json-output` and the session-start
+tree context.
+
+**Business-language routing hints:**
+- sales, revenue, GMV, AOV, basket, incentives -> `revenue`
+- growth, users, frequency, acquisition, reactivation -> `growth`
+- delivery, late, failed, courier, ops quality -> `operations`
+- conversion, checkout, cart, traffic, payment -> `conversion_funnel`
+
+When the user asks what they can do, turn available tree metadata into project-specific
+suggestions and end with a specific command, such as `/qluent:investigate revenue last month`.
+
 ## Commands
 
 - `/qluent:investigate` — Primary entry point. Bundles validation, trend, evaluation, and RCA in one call.
@@ -108,6 +125,11 @@ CLI/UI evidence labels: `observed_correlation`, `historical_elasticity`,
 For quick local demos or basic data, `/qluent:visualize` may still use the styled
 dashboard renderer (`render-charts.sh`) with the Qluent design system. Never write
 custom HTML, CSS, or Chart.js code by hand.
+
+After a successful investigation, offer outcome-shaped report follow-ups when the data
+supports them: an RCA report for driver decomposition, a mix-shift report when segment
+or mix effects are present, or an elasticity report for a selected lever/outcome. Use
+custom HTML only as an explicit local fallback when the UI report contract is unavailable.
 
 All qluent analysis commands should pipe through `tee` to auto-save visualization data:
 

--- a/plugins/qluent/scripts/post-bash.sh
+++ b/plugins/qluent/scripts/post-bash.sh
@@ -224,6 +224,7 @@ fi
 # Contextual follow-up suggestions
 if $is_investigate; then
   echo "  → Follow-up skills: /qluent:visualize (RcaReportSpec/charts), /qluent:rca (root cause), /qluent:trend (multi-period), /qluent:compare (cross-tree)"
+  echo "  → Report options: RCA report, mix-shift report when segment/mix effects exist, or elasticity report for a selected lever/outcome."
 fi
 
 if $is_trend || $is_rca || $is_compare; then

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -86,7 +86,11 @@ print()
 print('Fallback rule: if a requested cut is unavailable on the chosen tree, keep the same windows and pivot to the closest tree that lists that dimension.')
 print('Combine the original tree for KPI-specific explanation with the fallback tree for segmentation instead of stopping at the limitation.')
 print()
-print('Ask a business performance question or use /qluent:investigate to start.')
+print('Business-language routing hints: revenue/sales/GMV/AOV -> revenue; growth/users/acquisition/reactivation -> growth; delivery/late/failed/courier/ops quality -> operations; conversion/checkout/cart/traffic/payment -> conversion_funnel.')
+print('On first run, orient the user from this tree metadata and offer one concrete first command. Use qluent whoami/status/suggestions only when available; do not probe unsupported project/status commands.')
+print('After an investigation, offer an RCA report, mix-shift report, or elasticity report through /qluent:visualize before any local HTML fallback.')
+print()
+print('Ask a business performance question or use /qluent:investigate to start, for example /qluent:investigate revenue last month.')
 " 2>/dev/null) || context=""
 
 if [ -n "$context" ]; then


### PR DESCRIPTION
Fixes #19

Adds first-run orientation guidance, tree routing hints, and post-investigation report options through /qluent:visualize.

Validation:
- bash -n plugins/qluent/scripts/session-start.sh
- bash -n plugins/qluent/scripts/post-bash.sh