### PR TITLE
[codex] Surface period normalization caveats

### DIFF
--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -84,7 +84,10 @@ Build `sections[]` in the order that best tells the returned story, using only s
 backed by actual qluent fields:
 
 1. `root_movement`: root metric, current/comparison windows, absolute and percentage
-   movement, tree id/label, and any server-provided period labels.
+   movement, per-day normalized movement when available, tree id/label, and any
+   server-provided period labels. If current and comparison windows have different day
+   counts, add a caveat near the headline/root movement. Use deterministic normalized
+   delta fields if returned; otherwise state that the normalized field/query is missing.
 2. `driver_decomposition`: RCA driver findings, direct contributors, Shapley effects,
    materiality, confidence/evidence coverage, and supporting takeaways.
 3. `material_segment_scan`: `root_cause.findings[].segment_findings` and material
@@ -105,7 +108,8 @@ Every material section must preserve deterministic provenance:
   dimension/value when present, exact current/comparison windows, materiality, and
   confidence/evidence coverage.
 - Carry caveats from returned `gaps`, low confidence, sparse samples, missing dimensions,
-  unsupported cuts, guardrail warnings, or stale windows into top-level `caveats[]`.
+  unsupported cuts, guardrail warnings, stale windows, or unequal current/comparison
+  period lengths into top-level `caveats[]`.
 - Carry result references and data lineage into `sources[]`; do not cite unstated data.
 - Use CLI/UI evidence labels exactly when present: `observed_correlation`,
   `historical_elasticity`, `model_estimate`, and `experiment_backed`.
@@ -170,6 +174,9 @@ Write the complete dashboard to `/tmp/qluent-viz.html`:
 - All data values should use `var(--font-mono)` font family
 - Color positive deltas green, negative red
 - Make it responsive with the 768px breakpoint
+- Include a visible period-length caveat when current and comparison windows have
+  different day counts. If normalized deltas are present in the JSON, show them; if not,
+  state that normalized delta evidence was not returned.
 
 ### Data extraction patterns
 
@@ -212,6 +219,7 @@ xdg-open /tmp/qluent-viz.html
   whenever deterministic RCA or elasticity output is available
 - Do not hand-roll report HTML when the UI report contract can be used
 - Preserve deterministic provenance, caveats, date windows, materiality, and evidence labels
+- Preserve period comparability caveats in both `RcaReportSpec` output and HTML fallback
 - Use the `dashboard-design` skill for all design decisions — do not invent new styles
 - Section titles must be insight statements, not generic labels
 - Only include sections backed by actual data — never generate placeholder charts

--- a/plugins/qluent/templates/render-charts.html
+++ b/plugins/qluent/templates/render-charts.html
@@ -165,6 +165,19 @@
     line-height: 1.5;
   }
   .finding-item:last-child { border-bottom: none; }
+  .caveat-card {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-radius: 8px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+    color: #92400e;
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+  .caveat-card strong {
+    color: #78350f;
+  }
 
   details summary {
     cursor: pointer;
@@ -318,11 +331,35 @@ function fmtPct(v) {
   if (v == null) return '\u2014';
   return (v >= 0 ? '+' : '') + (v * 100).toFixed(1) + '%';
 }
+function fmtPctFlexible(v) {
+  if (v == null || Number.isNaN(Number(v))) return null;
+  const n = Number(v);
+  const ratio = Math.abs(n) > 1 ? n / 100 : n;
+  return fmtPct(ratio);
+}
 function deltaClass(v) {
   if (v == null || v === 0) return 'delta-neutral';
   return v > 0 ? 'delta-positive' : 'delta-negative';
 }
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function daysBetweenInclusive(win) {
+  if (!win?.date_from || !win?.date_to) return null;
+  const start = new Date(win.date_from + 'T00:00:00Z');
+  const end = new Date(win.date_to + 'T00:00:00Z');
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+  return Math.round((end - start) / 86400000) + 1;
+}
+function pickNormalizedDelta(data) {
+  const candidates = [
+    data?.evaluation?.per_day_delta_ratio,
+    data?.evaluation?.normalized_delta_ratio,
+    data?.evaluation?.daily_delta_ratio,
+    data?.root_cause?.normalized_delta_ratio,
+    data?.period_normalization?.delta_ratio,
+    data?.period_normalization?.per_day_delta_ratio
+  ];
+  return candidates.find(v => v != null);
+}
 </script>
 
 <div class="main">
@@ -335,6 +372,9 @@ function esc(s) { const d = document.createElement('div'); d.textContent = s; re
 
 <!-- KPI cards -->
 <div class="kpi-row" id="kpi-row"></div>
+
+<!-- Period caveats -->
+<div class="caveat-card hidden" id="period-caveat"></div>
 
 <script>
 (function() {
@@ -362,6 +402,19 @@ function esc(s) { const d = document.createElement('div'); d.textContent = s; re
           <div class="kpi-label">${esc(c.label || c.node_id)}</div>
         </div>`);
     });
+  }
+
+  const currentDays = daysBetweenInclusive(qdata.current_window);
+  const comparisonDays = daysBetweenInclusive(qdata.comparison_window);
+  if (currentDays && comparisonDays && currentDays !== comparisonDays) {
+    const normalized = fmtPctFlexible(pickNormalizedDelta(qdata));
+    const raw = fmtPctFlexible(qdata.evaluation?.delta_ratio);
+    const caveat = document.getElementById('period-caveat');
+    const normalizedText = normalized
+      ? ` Per-day normalized delta: ${esc(normalized)}.`
+      : ' Per-day normalized delta was not returned; request normalized delta fields before treating the raw change as like-for-like.';
+    caveat.innerHTML = `<strong>Period comparability:</strong> current window is ${currentDays} days and comparison window is ${comparisonDays} days. Raw delta${raw ? ` is ${esc(raw)}` : ''}.${normalizedText}`;
+    caveat.classList.remove('hidden');
   }
 
   // Pre-compute shared eval tree data for chart sections


### PR DESCRIPTION
Fixes #22

Adds report-spec guidance and fallback HTML rendering for unequal current/comparison period lengths. Uses normalized delta fields when returned and states when normalized delta evidence is missing.

Validation:
- Rendered sample March-vs-February JSON through the fallback template and confirmed period caveat code is present in the generated HTML.