### PR TITLE
[codex] Add qluent deep-dive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,54 @@ Or use slash commands directly:
 
 | Command | What it does |
 |---|---|
+| `/qluent:deep-dive` | Cross-tree executive narrative across all configured metric trees |
 | `/qluent:investigate` | Full analysis: validation, trend, evaluation, and RCA |
 | `/qluent:trend` | Multi-period trend analysis |
 | `/qluent:rca` | Root cause analysis with Shapley attribution |
 | `/qluent:compare` | Side-by-side metric tree comparison |
 | `/qluent:setup` | Check installation and configuration |
 
-Start with `/qluent:investigate`. The other commands are for follow-up drill-downs.
+Start with `/qluent:investigate` for a specific metric tree. Use
+`/qluent:deep-dive` when you need one executive read across the whole business.
+The other commands are for follow-up drill-downs.
 
 ```bash
+/qluent:deep-dive last week
+/qluent:deep-dive --period "this month" --yes
+/qluent:deep-dive 2026-04-01:2026-04-28
 /qluent:investigate why did revenue drop last week?
 /qluent:trend revenue --periods 8 --grain week
 /qluent:compare revenue orders --period "last month"
 ```
+
+## Cross-tree deep dives
+
+`/qluent:deep-dive [period]` calls:
+
+```bash
+qluent trees deep-dive --json-output --period "<period>"
+```
+
+The CLI runs investigations across all configured trees in parallel and returns one
+bundled JSON payload. Claude then synthesizes the bundle into a single narrative with:
+
+- **Headline** — which root metrics moved
+- **Concentration** — segments that show up across trees
+- **Mechanism** — whether the movement looks like volume, basket, conversion, mix,
+  operational quality, cost, margin, or timing
+- **Caveats** — errored trees, skipped cuts, low confidence, or sparse data
+- **Next-best drills** — ranked, copy-pasteable `/qluent:*` follow-up commands
+
+Because this can run several investigations at once, the command confirms before
+execution. Use `--yes` for autonomous mode after you have decided the cost is acceptable:
+
+```bash
+/qluent:deep-dive "last week" --yes
+```
+
+Requires a qluent CLI release that includes `qluent trees deep-dive` from
+`qluent-cli#40`. Older CLIs are detected and the command exits with an upgrade warning
+instead of falling back to separate tree investigations.
 
 ## License
 

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -15,6 +15,7 @@ segment dimensions — use that context to tailor suggestions.
 - **Root cause analysis** with Shapley attribution — mathematically exact driver decomposition
 - **Trend analysis** — multi-period tracking with anomaly detection
 - **Tree comparison** — side-by-side mechanism validation (volume vs mix vs rate shifts)
+- **Cross-tree deep dive** — one consented executive narrative across all configured trees
 - **Segment drill-down** — find which segments concentrate a movement
 - **Sensitivity analysis** — elasticity coefficients showing which sub-metrics are the biggest levers for the root KPI
 - **Lever impact analysis** — scenario-style estimates for how +1%, +5%, or +10% changes in a sub-metric would move the root KPI
@@ -31,15 +32,17 @@ tree for the latest period and present real findings rather than listing feature
 ## Commands
 
 - `/qluent:investigate` — Primary entry point. Bundles validation, trend, evaluation, and RCA in one call.
+- `/qluent:deep-dive` — Opt-in cross-tree executive read. Confirms cost, then runs `qluent trees deep-dive --json-output --period`.
 - `/qluent:trend` — Multi-period trend analysis. Use as a follow-up.
 - `/qluent:rca` — Standalone root cause analysis. Use as a follow-up.
 - `/qluent:compare` — Side-by-side tree comparison. Use as a follow-up.
 - `/qluent:visualize` — Render the latest analysis as interactive HTML charts in the browser.
 - `/qluent:setup` — Check installation and configuration.
 
-**IMPORTANT: Always start with `/qluent:investigate`.** Do NOT manually chain `trend`,
-`rca`, or `compare` as your first step. The `investigate` command bundles all of these
-into a single call. Running individual commands is slower and misses agent-level analysis.
+**IMPORTANT: Start with `/qluent:investigate` for single-tree questions and
+`/qluent:deep-dive` only when the user explicitly wants a cross-business view.** Do NOT
+manually chain `trend`, `rca`, `compare`, or separate investigations as your first step.
+The bundled commands preserve deterministic server analysis and cost consent.
 
 ## Deterministic tree-query protocol
 
@@ -117,12 +120,31 @@ qluent trees investigate ... --json-output 2>&1 | tee /tmp/qluent-viz-data.json
 
 This makes `/qluent:visualize` immediately available after any analysis.
 
+## Cross-tree deep dives
+
+Use `/qluent:deep-dive [period]` when the user asks what changed across the business,
+requests an executive overview, or wants revenue, growth, operations, and funnel context
+stitched together. It is opt-in only and must confirm before running unless the user
+passes `--yes`.
+
+The command depends on `qluent trees deep-dive` from qluent-cli#40. If the installed CLI
+does not expose that subcommand, warn and exit instead of manually fanning out to
+individual tree investigations.
+
+Synthesize the returned bundle into one narrative:
+- Headline: which root metrics moved
+- Concentration: segments that repeat across trees
+- Mechanism: volume vs basket vs conversion vs ops, backed by returned decomposition
+- Caveats: errored trees, low confidence, sparse data, skipped cuts
+- Next-best drills: ranked concrete `/qluent:*` commands across trees
+
 ## Use built-in skills, don't improvise
 
 This plugin provides purpose-built skills for common workflows. **Always use them instead of improvising.**
 
 - Charts or RCA reports → `/qluent:visualize` (prefer `RcaReportSpec`; never write custom HTML)
 - Analysis → `/qluent:investigate` (never manually chain CLI commands as a first step)
+- Cross-business executive read → `/qluent:deep-dive` (confirm cost; never auto-fire)
 - Follow-ups → `/qluent:trend`, `/qluent:rca`, `/qluent:compare`, or `qluent trees levers` (not ad-hoc scripts)
 
 The PostToolUse hook will remind you about available skills after qluent commands complete. Follow those reminders.

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -1,0 +1,192 @@
+---
+description: Run a consented cross-tree deep dive and synthesize one executive narrative across all metric trees
+argument-hint: "[period | --period 'last week' | YYYY-MM-DD:YYYY-MM-DD] [--yes] [--brief]"
+allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read
+---
+
+# Deep dive across metric trees
+
+Use this command when the user wants one unified answer to "what changed across the
+business?" across revenue, growth, operations, conversion funnel, and any other
+configured trees.
+
+This command is opt-in and can be expensive: it runs investigations across all trees in
+parallel through the deterministic qluent CLI. Do not run it from SessionStart or as an
+implicit first step.
+
+## Step 1: Check CLI availability and capability
+
+Verify qluent is installed:
+
+```bash
+which qluent
+```
+
+If qluent is missing, stop and tell the user:
+
+```text
+qluent is not installed. Run /qluent:setup first, then retry /qluent:deep-dive.
+```
+
+Then verify the installed CLI supports the deep-dive subcommand:
+
+```bash
+qluent trees deep-dive --help
+```
+
+If the command exits non-zero or says the subcommand is unknown, stop and tell the user:
+
+```text
+This qluent CLI does not support `qluent trees deep-dive` yet. Upgrade to the release
+that includes qluent-cli#40, then retry `/qluent:deep-dive`.
+```
+
+Do not fall back to running four separate `qluent trees investigate` commands; that
+would change the cost profile and lose the bundled cross-tree contract.
+
+## Step 2: Resolve the requested period
+
+Accept any of these forms:
+
+- `/qluent:deep-dive last week`
+- `/qluent:deep-dive --period "this month"`
+- `/qluent:deep-dive 2026-04-01:2026-04-28`
+- `/qluent:deep-dive last week --yes`
+
+Remove control flags such as `--yes` and `--brief` before resolving the period.
+
+If `$ARGUMENTS` includes `--period`, use that value verbatim.
+If `$ARGUMENTS` has remaining non-flag text, use that text verbatim as the period.
+If no period is provided, ask the user for one with `AskUserQuestion` before continuing.
+
+Supported examples include "last week", "this month", "last 30 days", and explicit
+ISO ranges such as `YYYY-MM-DD:YYYY-MM-DD` when supported by the CLI.
+
+## Step 3: Confirm cost and scope
+
+Unless `$ARGUMENTS` includes `--yes`, ask for confirmation with `AskUserQuestion`
+before running the deep dive:
+
+```text
+Run a cross-tree deep dive for <period>? This runs investigations across all configured
+trees in parallel and may be slower or more expensive than a single-tree investigation.
+```
+
+Offer exactly two choices:
+
+- `Run deep dive`
+- `Cancel`
+
+If the user cancels, stop without running qluent.
+
+If `$ARGUMENTS` includes `--yes`, skip this confirmation and run autonomously.
+
+## Step 4: Run the bundled deep-dive command
+
+Before running the command, give one concise progress note:
+
+```text
+Running qluent cross-tree deep dive for <period>; this may take a minute because it
+investigates all configured trees in parallel.
+```
+
+Run the deterministic bundled command and save the JSON bundle for this session:
+
+```bash
+qluent trees deep-dive --json-output --period "<period>" 2>&1 | tee /tmp/qluent-deep-dive-bundle.json
+```
+
+If qluent exits non-zero:
+
+- Surface the CLI error plainly.
+- If the error indicates an unknown command, tell the user to upgrade to the release
+  containing qluent-cli#40.
+- If the error indicates auth/configuration, tell the user to run `/qluent:setup`.
+- Do not synthesize a report from partial shell text.
+
+## Step 5: Parse the bundled payload
+
+Read the returned JSON from the tool result. Treat the bundle as the only source of
+quantitative truth.
+
+Expected payload shape may evolve, so inspect fields by meaning rather than hardcoding
+one exact schema. Look for:
+
+- bundle-level period/current/comparison windows
+- per-tree result objects with tree id, label, status, root movement, evaluation,
+  root cause, trend, segment findings, levers, agent findings, gaps, and errors
+- cross-tree findings, concentrations, correlations, shared segments, recommended
+  next steps, caveats, and confidence metadata
+
+If a tree has `error`, `status: error`, missing required evidence, low confidence, sparse
+data, or skipped analysis, carry that into Caveats. Do not hide failed trees.
+
+## Step 6: Synthesize one cross-tree narrative
+
+Return one markdown report. Do not concatenate four tree reports.
+
+Use this structure:
+
+```markdown
+## Headline
+One short executive summary of which root metrics moved and the net business read.
+
+## Concentration
+Cross-reference segments that appear across trees. Highlight repeated countries,
+channels, cohorts, products, platforms, verticals, or customer segments. Distinguish
+shared segment evidence from tree-specific evidence.
+
+## Mechanism
+Explain the strongest supported mechanism across trees: volume, basket/AOV, conversion,
+mix, ops quality, supply, cost, margin, or timing. Use the returned decomposition,
+segment, lever, and trend fields. Be explicit when the mechanism is not resolved.
+
+## Caveats
+List errored trees, skipped cuts, stale/missing data, low confidence, sparse samples,
+or unsupported segment overlaps.
+
+## Next-best drills
+Rank concrete follow-up commands across trees, not just within one tree.
+```
+
+Rules for synthesis:
+
+- Ground every material quantitative claim in the returned JSON.
+- Prefer cross-tree convergence over per-tree trivia.
+- If revenue and conversion move in opposite directions, explain the tension.
+- If operations and conversion share a segment, call out the possible operational
+  mechanism but label it as an observed relationship unless the returned data supports
+  stronger causal language.
+- If a single tree dominates the story, say that and explain whether other trees confirm,
+  contradict, or are inconclusive.
+- Separate facts, interpretation, caveats, and recommendations.
+- Keep the narrative concise by default. If `--brief` is present, use shorter bullets
+  under each heading but still include all five headings.
+
+## Next-best drill command format
+
+Recommended next drills must be copy-pasteable and valid for this plugin/project.
+
+Use exact tree ids, periods, and dimensions from the bundle. Prefer qluent's returned
+recommended next steps when they are concrete. If you need to formulate a command, use
+only commands supported by this plugin:
+
+```bash
+/qluent:investigate <tree_id> --period "<period>"
+/qluent:rca <tree_id> --period "<period>" --segment-by <dimension>
+/qluent:trend <tree_id> --periods 8 --grain week
+/qluent:compare <tree_id_1> <tree_id_2> --period "<period>"
+```
+
+Rank next drills by expected ability to resolve the biggest open question, not by tree
+order. Include why each drill is recommended in one sentence.
+
+## Rules
+
+- Always check for qluent and the `trees deep-dive` subcommand before running analysis.
+- Always call `qluent trees deep-dive --json-output --period "<period>"`.
+- Always confirm before running unless `--yes` is present.
+- Never auto-fire from SessionStart.
+- Never manually fan out to individual tree investigations as a fallback.
+- Per-tree errors and low-confidence findings must appear in Caveats.
+- Recommendations must be concrete slash commands for this plugin.

--- a/plugins/qluent/scripts/post-bash.sh
+++ b/plugins/qluent/scripts/post-bash.sh
@@ -17,21 +17,24 @@ command=$(printf '%s' "${TOOL_INPUT:-}" | "$jq_bin" -r '.command // empty' 2>/de
 
 # Detect which type of command was run
 is_investigate=false
+is_deep_dive=false
 is_trend=false
 is_rca=false
 is_compare=false
 
 [[ "$command" == *"investigate"* ]] && is_investigate=true
+[[ "$command" == *"deep-dive"* ]] && is_deep_dive=true
 [[ "$command" == *"trend"* ]] && is_trend=true
 [[ "$command" == *"rca"* ]] && is_rca=true
 [[ "$command" == *"compare"* ]] && is_compare=true
 
 # Only act on analysis commands (not list, validate, setup, etc.)
-if ! $is_investigate && ! $is_trend && ! $is_rca && ! $is_compare; then
+if ! $is_investigate && ! $is_deep_dive && ! $is_trend && ! $is_rca && ! $is_compare; then
   exit 0
 fi
 
 viz_file=/tmp/qluent-viz-data.json
+deep_dive_file=/tmp/qluent-deep-dive-bundle.json
 catalog_file=/tmp/qluent-tree-capabilities.json
 
 parse_requested_dims_from_command() {
@@ -210,20 +213,30 @@ echo "[Qluent] Analysis complete."
 
 # Viz data reminder
 if [[ "$command" == *"--json-output"* ]]; then
-  if [ -f "$viz_file" ]; then
+  if $is_deep_dive; then
+    if [ -f "$deep_dive_file" ]; then
+      echo "  → Deep-dive bundle saved. Synthesize one cross-tree narrative; do not split it into separate tree reports."
+    else
+      echo "  → To cache the deep-dive bundle for follow-up questions, pipe output through: | tee /tmp/qluent-deep-dive-bundle.json"
+    fi
+  elif [ -f "$viz_file" ]; then
     echo "  → Visualization data saved. Use /qluent:visualize to produce a UI RcaReportSpec first; use styled HTML only as a local fallback."
   else
     echo "  → To enable /qluent:visualize, pipe output through: | tee /tmp/qluent-viz-data.json"
   fi
 fi
 
-if [[ "$command" == *"--json-output"* ]]; then
+if [[ "$command" == *"--json-output"* ]] && ! $is_deep_dive; then
   build_fallback_guidance "$command" "$viz_file" "$catalog_file"
 fi
 
 # Contextual follow-up suggestions
 if $is_investigate; then
   echo "  → Follow-up skills: /qluent:visualize (RcaReportSpec/charts), /qluent:rca (root cause), /qluent:trend (multi-period), /qluent:compare (cross-tree)"
+fi
+
+if $is_deep_dive; then
+  echo "  → Follow-up skills: /qluent:investigate, /qluent:rca, /qluent:trend, or /qluent:compare using the ranked next drills from the report."
 fi
 
 if $is_trend || $is_rca || $is_compare; then


### PR DESCRIPTION
## Summary

Adds a new /qluent:deep-dive slash command for consented cross-tree executive analysis.

## What changed

- Added plugins/qluent/commands/deep-dive.md with CLI capability checks, period parsing, cost confirmation, bundled qluent trees deep-dive --json-output --period execution, synthesis guidance, caveat handling, and ranked next-drill command formatting.
- Documented /qluent:deep-dive in the README with examples, cost behavior, and the qluent-cli#40 dependency.
- Updated plugin guidance in CLAUDE.md so deep dives are opt-in and not confused with single-tree investigation.
- Updated the post-bash hook to recognize deep-dive commands and point agents at the cached cross-tree bundle instead of the single-tree visualization file.

## Validation

- bash -n plugins/qluent/scripts/post-bash.sh
- Simulated the post-bash hook with a qluent trees deep-dive --json-output command

## Notes

The actual qluent trees deep-dive command was not run because it depends on the qluent-cli#40 release.