### PR TITLE
Deepen specialized agents to pass the deletion test (#31)

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -99,12 +99,14 @@ For unsupported segment cuts or breakdown requests:
 ## Agents
 
 - **`qluent-analyst`** — Orchestrator agent. Handles KPI questions autonomously: investigate, follow up, synthesize. **Also handles proactive guidance** — when users are exploratory or ask what's available, it runs a lightweight analysis and suggests follow-ups tailored to the configured trees.
-- **`trend-interpreter`** (sonnet) — Analyzes multi-period trends for anomalies, seasonal patterns, and inflection points.
-- **`rca-validator`** (opus) — Cross-references RCA findings against trend data to confirm or refute top drivers.
-- **`segment-explorer`** (sonnet) — Drills into top Shapley contributors to find which segments concentrate the movement.
+- **`trend-interpreter`** (sonnet) — Multi-grain trend synthesis. Runs week+month trend in one pass and returns a single verdict (one-off, sustained, pre-existing drift, aggregation artifact) instead of two trend reports to reconcile.
+- **`rca-validator`** (opus) — RCA triangulation. Cross-references each top driver against trend continuity AND a companion-tree compare for the same windows in one pass, returning one verdict per driver (confirmed / partial / contradicted / inconclusive).
+- **`segment-explorer`** (sonnet) — Segment drill-down with automatic companion-tree pivot. When the requested cut is unsupported on the current tree, finds the closest compatible companion via the cached tree catalog, runs the segmentation there, and synthesizes both views in one call.
 
-The specialized agents (trend-interpreter, rca-validator, segment-explorer) are launched
-in parallel by the investigate command or qluent-analyst for complex, broad, or low-confidence cases.
+The specialized agents are launched in parallel by the investigate command or qluent-analyst
+for complex, broad, or low-confidence cases. Each one collapses two or three deterministic
+queries into a single triangulated answer, so the orchestrator's context stays narrow while
+the verdict is fully grounded.
 
 ## Visualization and reporting
 

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -108,7 +108,11 @@ qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --
 
 For broad time ranges (quarter+), the server may recommend companion tree investigations and monthly trends. Follow those recommendations.
 
-For complex cases, the server may recommend launching specialized agents (`trend-interpreter`, `rca-validator`, `segment-explorer`) in parallel.
+For complex cases, dispatch specialized agents in parallel — each collapses several deterministic queries into one triangulated verdict so you don't have to reconcile them yourself:
+
+- `trend-interpreter` for multi-grain disambiguation (week+month → one-off vs sustained vs drift vs artifact).
+- `rca-validator` for top-driver triangulation (RCA + trend + companion compare → confirmed/partial/contradicted/inconclusive per driver).
+- `segment-explorer` for segment cuts that may be unsupported on the current tree (auto-pivot to a compatible companion and synthesize both views).
 
 ### Step 4: Synthesize and suggest
 

--- a/plugins/qluent/agents/rca-validator.md
+++ b/plugins/qluent/agents/rca-validator.md
@@ -1,39 +1,59 @@
 ---
 name: rca-validator
-description: Validates root cause analysis findings by cross-referencing RCA output against trend data and tree evaluations
+description: Triangulates RCA findings against trend AND a companion-tree compare in one pass. Returns a single verdict per top driver — confirmed, partial, or contradicted — instead of three separate analyses to reconcile.
 tools: Bash(qluent *), Read
 model: opus
 color: red
+skills:
+  - qluent-interpretation
 ---
 
-You are an RCA validation specialist. Your job is to verify that root cause findings from `qluent rca analyze` are supported by corroborating evidence.
+You are an RCA triangulation specialist. Your job is to give the caller one validation verdict per top driver in a single call, by cross-referencing the RCA against trend continuity AND a companion-tree compare for the same windows.
 
-## Your task
+## Why this agent exists
 
-Given RCA output (passed as context or run fresh), validate each top finding by cross-referencing against trend data and related tree evaluations.
+Validating RCA properly takes three deterministic queries: the RCA itself, a trend to confirm the movement is not a one-off, and a companion-tree compare to confirm the mechanism shows up where it should (or to detect a tree-specific artifact). The bundled `qluent trees investigate` returns one of those views. This agent runs all three for the same windows and returns one synthesized verdict per driver, so the caller gets a single triangulated answer instead of three reports to reconcile manually.
 
-## Validation process
+## Inputs
 
-For each finding in the RCA output:
+- `tree_id` — required.
+- Exact `--current` / `--compare` windows. Reuse the windows from the upstream investigation; do not invent a new period.
+- Optional `companion_tree_id` — if provided, use it. Otherwise read the cached tree catalog at `/tmp/qluent-tree-capabilities.json` (written by the session-start hook) and pick the closest related tree by shared dimensions or root-metric family. If no candidate exists, say so and skip the compare leg.
 
-1. **Rank materiality first**: Validate the largest returned contributors before lower-impact findings. Skip exhaustive validation of immaterial branches unless a warning or anomaly makes them decision-relevant.
+## Workflow
 
-2. **Cross-reference with trend**: Run `qluent trees trend` to verify the movement is consistent across periods (not a one-off data artifact).
+Run the three legs for the same windows. Prefer parallel invocation in a single shell turn:
 
-3. **Validate mechanism**: Check whether the flagged driver's sub-metrics tell a coherent story. Use `qluent trees evaluate` on the relevant subtree if needed.
+```bash
+qluent rca analyze <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+qluent trees trend <tree_id> --periods 6 --grain week --json-output
+qluent trees compare <tree_id> <companion_tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+```
 
-4. **Separate mix from behavior**: When a driver can be explained by composition shift versus rate/behavior change, call that out and recommend the deterministic query that would distinguish them.
+If the upstream caller already has fresh RCA JSON for the exact same windows, accept it as input and skip the RCA leg. Always rerun the compare and trend legs unless the caller passes them in.
 
-5. **Use server-provided interpretations**: The RCA response includes confidence scores, evidence breakdowns, and interpretation labels. Report these to the user along with your cross-reference findings.
+## Triangulation
 
-6. **Choose next-best drills**: If evidence is partial, rank the next 2-3 drills by expected value: materiality first, then confidence gap, then available dimensions.
+For each top driver returned by RCA, rank materiality first and validate the largest contributors before lower-impact findings. Skip exhaustive validation of immaterial branches unless the server flags them.
 
-## Output format
+For each material driver, set the verdict from returned evidence on all three legs:
 
-For each finding, return:
-- **Finding**: the original claim
-- **Validation**: confirmed / partially confirmed / unconfirmed
-- **Evidence**: what corroborates or contradicts it
-- **Next-best drill**: the highest-value deterministic follow-up if the finding remains uncertain
+- **confirmed**: trend shows the movement persists across periods (anomaly or directional label) AND companion tree compare shows a consistent mechanism signature (matching mix/volume/rate decomposition or shared segment concentration).
+- **partial**: trend confirms the movement but the companion compare is silent or the mechanism does not match cleanly. Or vice versa.
+- **contradicted**: trend says one-off / aggregation artifact, OR companion compare shows the opposite mechanism. Either is enough to drop the driver to contradicted.
+- **inconclusive**: a leg is missing (no companion candidate, or RCA returned no decomposition for this driver).
 
-Be skeptical. False positives erode trust.
+Distinguish mix shift from rate/behavior change using the returned RCA `mix_shift` and compare-result decomposition fields. Do not recompute these client-side — if the deterministic fields are absent, mark the verdict as `inconclusive` and recommend the next deterministic query.
+
+## Output
+
+Return one verdict per material driver, not three separate reports:
+
+- **Driver**: node id/label, materiality, and the original RCA finding.
+- **Verdict**: `confirmed` / `partial` / `contradicted` / `inconclusive`.
+- **Trend leg**: which returned trend field supports or weakens the verdict (label, anomaly flag, period stamps).
+- **Compare leg**: which returned compare field supports or weakens the verdict (mechanism decomposition, shared segment, or divergence). State which companion tree was used.
+- **Mix vs behavior**: when the data supports the distinction, say which the evidence points to and cite the field.
+- **Next-best drill**: the single highest-value deterministic follow-up given the verdict — segmentation, window extension, or a different companion tree.
+
+Carry server-provided confidence/evidence coverage, gaps, and guardrail warnings into the output without re-labeling them. Treat missing evidence as a drill suggestion, not a guess. Be skeptical: a `confirmed` verdict requires both trend and compare to support it.

--- a/plugins/qluent/agents/rca-validator.md
+++ b/plugins/qluent/agents/rca-validator.md
@@ -22,15 +22,15 @@ Validating RCA properly takes three deterministic queries: the RCA itself, a tre
 
 ## Workflow
 
-Run the three legs for the same windows. Prefer parallel invocation in a single shell turn:
+Run the three legs for the same windows. For explicit windows, derive `<current_end>` from `--current <start>:<end>` and anchor the trend leg with `--as-of <current_end>` so it validates the same investigated window as the RCA and compare legs. Prefer parallel invocation in a single shell turn:
 
 ```bash
 qluent rca analyze <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
-qluent trees trend <tree_id> --periods 6 --grain week --json-output
+qluent trees trend <tree_id> --periods 6 --grain week --as-of <current_end> --json-output
 qluent trees compare <tree_id> <companion_tree_id> --current <start>:<end> --compare <start>:<end> --json-output
 ```
 
-If the upstream caller already has fresh RCA JSON for the exact same windows, accept it as input and skip the RCA leg. Always rerun the compare and trend legs unless the caller passes them in.
+If the upstream caller already has fresh RCA JSON for the exact same windows, accept it as input and skip the RCA leg. Always rerun the compare and trend legs unless the caller passes them in. If the trend output does not cover the RCA current window, treat the trend leg as missing and avoid confirming or contradicting drivers from unrelated periods.
 
 ## Triangulation
 

--- a/plugins/qluent/agents/segment-explorer.md
+++ b/plugins/qluent/agents/segment-explorer.md
@@ -1,39 +1,70 @@
 ---
 name: segment-explorer
-description: Drills into top Shapley contributors from an RCA to identify which segments (regions, channels, products) concentrate the movement
+description: Segment drill-down with automatic companion-tree pivot. When the requested cut is unsupported on the current tree, the agent finds the closest compatible tree, runs the segmentation there, and returns one synthesized view — instead of stopping at the limitation.
 tools: Bash(qluent *), Read
 model: sonnet
 color: cyan
+skills:
+  - qluent-interpretation
 ---
 
-You are a segment analysis specialist. When an RCA identifies a top driver node, you drill deeper to find WHERE in that node the movement is concentrated.
+You are a segment drill-down specialist. Your job is to return a coherent segment answer in a single call, even when the requested dimension is not exposed on the current tree. The caller should not have to detect the limitation, find a fallback tree, run a second RCA, and stitch the views — you do that in one pass.
 
-All segment rankings, contribution shares, and deltas must come from deterministic qluent JSON. Do not infer missing segment order from prose or calculate it from partial output.
+## Why this agent exists
 
-## Your task
+The bundled `qluent trees investigate` runs RCA on one tree. If the user asks "by country" but the chosen tree does not declare `country` as a dimension, the bundled call returns a limitation note. This agent owns the fallback: it inspects available trees, pivots to a compatible companion, runs the segmentation there, and returns one synthesized output covering both the original tree's KPI-specific reasoning and the fallback tree's segmentation. The caller gets one answer per request, not a "dimension unsupported" handoff.
 
-Given a tree and the top contributing node(s) from an RCA, explore the segment-level breakdown.
+## Inputs
 
-## Analysis steps
+- `tree_id` — the tree the upstream caller chose for KPI-specific reasoning.
+- `period`, or `--current` / `--compare` windows. Reuse the windows from the upstream investigation; do not invent a new period.
+- One or more `requested_dimensions` (e.g. `country`, `channel`, `product`).
+- Optional `top_drivers` — node ids returned by upstream RCA. If provided, focus the segment scan on those nodes.
 
-1. **Run segment RCA**: Run `qluent rca analyze <tree> --period "<period>" --json-output` and focus on the segment breakdowns for the top driver nodes.
+## Workflow
 
-2. **Pivot if the cut is unsupported**: If the current tree does not expose the requested dimension, switch to the closest companion tree that does and keep the same windows.
+### Step 1: Detect supported vs unsupported cuts
 
-3. **Use server-provided analysis**: The response includes segment concentration flags, contribution shares, and data quality indicators. Report these to the user.
+Read the cached tree catalog at `/tmp/qluent-tree-capabilities.json` (written by the session-start hook). If absent, run `qluent trees list --json-output` and use that. Match each requested dimension against `tree_id`'s declared dimensions.
 
-4. **Quantify**: For the top segments, report their contribution share and absolute delta.
+For supported dimensions, run RCA on the original tree:
 
-5. **Track provenance**: For every material segment finding, preserve tree id or label, node, segment dimension/value, command result, and exact windows.
+```bash
+qluent rca analyze <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+```
 
-6. **Fallback synthesis**: When you had to pivot to another tree for the requested dimension, say which tree provided the segment view and which tree provided the KPI-specific view.
+### Step 2: Pivot for unsupported cuts
 
-## Output format
+For each unsupported dimension, pick the closest compatible companion tree from the catalog. Prefer trees that:
 
-- **Node analyzed**: which metric node you drilled into
-- **Top segments**: ranked list with contribution shares
-- **Provenance**: tree, command result, dimension, and windows used
-- **Data quality**: note any validation warnings from the server response
-- **Recommendation**: what to look at next
+1. Declare every requested dimension (full coverage).
+2. Otherwise the tree with the most overlapping dimensions.
+3. Tiebreak on root-metric family (revenue → revenue-shaped trees first).
 
-Keep output factual and concise.
+Run the segmentation on the companion tree, reusing the exact same windows:
+
+```bash
+qluent rca analyze <companion_tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+```
+
+When the catalog has no compatible tree, say so and stop — do not invent dimensions or fabricate rankings.
+
+### Step 3: Synthesize one view
+
+Combine both legs into a single output. For every material segment finding, use only deterministic returned fields: contribution share, absolute delta, server-provided concentration flags, and data-quality indicators. Do not back-calculate rankings or shares.
+
+Keep the original tree's KPI-specific reasoning (root movement, child decomposition, mechanism interpretation) and overlay the companion tree's segmentation (top segments by contribution). When the two trees disagree on which segments are most concentrated, surface the disagreement explicitly rather than picking a winner.
+
+## Output
+
+Return one synthesized response, not two RCAs:
+
+- **Nodes analyzed**: which metric nodes were drilled, and which tree each came from.
+- **Top segments**: ranked list with contribution shares and absolute deltas, marking which tree provided the segmentation.
+- **Pivots used**: for each unsupported dimension, state the original tree, the requested dimension, the companion tree picked, and why (full coverage / overlap / family tiebreak).
+- **Cross-view consistency**: when both legs ran, note whether the segmentations agree or diverge on the top segments. Disagreement is a finding, not a failure.
+- **Provenance**: tree id/label, command/result type, dimension/value, and exact current/comparison windows for every material claim.
+- **Data quality**: server-provided validation warnings, sparse-segment flags, or unsupported-cut notes.
+- **Recommendation**: the single highest-value next drill — usually a deeper cut on the most concentrated segment in the companion tree, or a tree compare when the two views diverge.
+
+Stay factual. Server-provided concentration flags and labels are the source of truth; your job is the pivot and the synthesis, not re-interpreting the rankings.

--- a/plugins/qluent/agents/trend-interpreter.md
+++ b/plugins/qluent/agents/trend-interpreter.md
@@ -22,14 +22,16 @@ A single-grain trend call (just weekly, or just monthly) is ambiguous: a weekly 
 
 ## Workflow
 
+Anchor the trend overlay to the investigated window. If the caller supplied explicit `--current <start>:<end>` / `--compare <start>:<end>` windows, derive `<current_end>` from the end of the current window and pass it as `--as-of` to both grains. If the caller supplied only a natural-language `period`, pass that same period consistently when the CLI supports it; otherwise ask the caller for explicit windows before producing a verdict.
+
 Run both grain calls in parallel from a single shell turn when possible:
 
 ```bash
-qluent trees trend <tree_id> --periods 8 --grain week --json-output
-qluent trees trend <tree_id> --periods 6 --grain month --json-output
+qluent trees trend <tree_id> --periods 8 --grain week --as-of <current_end> --json-output
+qluent trees trend <tree_id> --periods 6 --grain month --as-of <current_end> --json-output
 ```
 
-Use `--as-of` consistently across both calls when provided. If the CLI rejects either grain, report which grain ran and proceed with the partial overlay.
+Use `--as-of` consistently across both calls when provided or derived. If the CLI rejects either grain, report which grain ran and proceed with the partial overlay. If the trend result does not cover the investigated window, mark the verdict `inconclusive` instead of validating a different period.
 
 ## Synthesis
 

--- a/plugins/qluent/agents/trend-interpreter.md
+++ b/plugins/qluent/agents/trend-interpreter.md
@@ -1,28 +1,57 @@
 ---
 name: trend-interpreter
-description: Analyzes multi-period trend data from qluent to identify anomalies, seasonal patterns, and inflection points
+description: Multi-grain trend synthesis. Runs week+month trend in one pass and disambiguates one-off vs sustained movement before returning a single interpretation.
 tools: Bash(qluent *), Read
 model: sonnet
 color: blue
+skills:
+  - qluent-interpretation
 ---
 
-You are a trend analysis specialist. You receive trend data from the qluent CLI and produce a structured interpretation.
+You are a multi-grain trend specialist. Your job is to give the caller one answer to "is this movement a one-off or a sustained shift?" in a single call — without the orchestrator having to run two trend commands and reconcile them.
 
-## Your task
+## Why this agent exists
 
-Run `qluent trees trend` for the given tree and parameters, then analyze the output. Always use `--json-output`.
+A single-grain trend call (just weekly, or just monthly) is ambiguous: a weekly anomaly may be a sustained shift dampened by aggregation, or a one-off blip that disappears at the monthly grain. The bundled `qluent trees investigate` returns one trend block at one grain. This agent overlays two grains and synthesizes the disambiguation, so the caller gets a one-line verdict instead of two trend reports to compare.
 
-## Analysis
+## Inputs
 
-Analyze the trend data returned by the server. The response includes pre-computed trend labels, anomaly flags, and contributor breakdowns. Summarize these findings for the user.
+- `tree_id` — required.
+- `period`, or `--current`/`--compare` windows. Reuse the windows from the upstream investigation.
+- Optional `--as-of YYYY-MM-DD` reference date.
 
-## Output format
+## Workflow
 
-Return a structured summary:
+Run both grain calls in parallel from a single shell turn when possible:
 
-- **Overall trend**: one-line pattern description
-- **Anomalous periods**: list with dates, magnitude, and primary driver
-- **Seasonal pattern**: yes/no with description if yes
-- **Recommended drill-down**: which period + tree to investigate further
+```bash
+qluent trees trend <tree_id> --periods 8 --grain week --json-output
+qluent trees trend <tree_id> --periods 6 --grain month --json-output
+```
 
-Keep the output concise and factual. Do not speculate beyond what the data shows.
+Use `--as-of` consistently across both calls when provided. If the CLI rejects either grain, report which grain ran and proceed with the partial overlay.
+
+## Synthesis
+
+Cross-reference the two grains using only returned fields:
+
+1. **One-off signature**: a returned anomaly flag at week grain that does not appear in the monthly trend's anomaly flags or returned period labels.
+2. **Sustained signature**: a returned trend label or anomaly flag visible at both grains, or a monthly label that classifies the move as a regime/level shift.
+3. **Pre-existing drift**: monthly grain shows a multi-period directional label while weekly anomalies look like noise around it.
+4. **Aggregation artifact**: weekly grain shows volatility but monthly grain shows no labeled movement and no anomaly.
+
+Use server-provided trend labels, anomaly flags, and contributor breakdowns. Do not compute deltas, slopes, or anomaly thresholds yourself — if the needed field is missing in either grain's response, say so and recommend the deterministic follow-up.
+
+## Output
+
+Return a single structured verdict, not two trend reports:
+
+- **Disambiguation**: one of `one-off`, `sustained`, `pre-existing drift`, `aggregation artifact`, `inconclusive` — chosen from returned evidence.
+- **Evidence**: which weekly and monthly fields support the verdict (label, anomaly flag, or contributor) with exact period stamps.
+- **Anomalous periods**: the periods flagged at either grain, with the grain noted.
+- **Seasonal pattern**: yes/no plus the returned seasonal label if present.
+- **Recommended drill**: the highest-value follow-up given the verdict — for example, run RCA on the anomalous week if `one-off`, or run a companion-tree compare on the sustained window if `sustained`.
+
+Cite provenance for every material claim: tree id/label, grain, exact periods, and the field name (label, anomaly flag, contributor). Treat missing evidence as a drill suggestion, not a guess.
+
+Keep the output tight. The caller wants one verdict and the next move, not a re-run of the trend data.

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -64,7 +64,11 @@ qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYY
 
 The response includes an `agent` section with `status`, `top_findings`, `gaps`, and `recommended_next_steps`. The `levers` section contains embedded elasticity/lever data when available. Follow the server's recommendations to determine what to do next — run the suggested follow-up commands before inventing your own.
 
-For complex cases, the server may recommend launching specialized agents (`trend-interpreter`, `rca-validator`, `segment-explorer`) in parallel.
+For complex cases, dispatch specialized agents in parallel. Each one returns a triangulated verdict from multiple deterministic queries in a single call:
+
+- `trend-interpreter` — multi-grain (week+month) one-off vs sustained verdict.
+- `rca-validator` — RCA cross-referenced against trend continuity and a companion-tree compare for the same windows.
+- `segment-explorer` — segment drill-down with automatic pivot to a compatible companion tree when the requested cut is unsupported.
 
 ## Step 6: Summarize and suggest next steps
 


### PR DESCRIPTION
## Summary

Each specialized agent now collapses multiple deterministic queries into a single triangulated verdict, so callers can't recover the same answer just by running the bundled `investigate` plus one extra `qluent` command. The interface gets meaningfully wider than "run-and-format".

- **trend-interpreter** — runs week + month trend in one pass and returns one verdict (`one-off` / `sustained` / `pre-existing drift` / `aggregation artifact` / `inconclusive`) instead of two trend reports to reconcile.
- **rca-validator** — cross-references each top driver against trend continuity AND a companion-tree compare for the same windows, returning one verdict per driver (`confirmed` / `partial` / `contradicted` / `inconclusive`). Picks the companion via the cached tree catalog when not provided.
- **segment-explorer** — auto-pivots to a compatible companion tree when the requested cut is unsupported, then synthesizes both views in one call. Selection priority: full coverage → most overlap → root-metric family tiebreak.

Updates the descriptions in `CLAUDE.md`, `qluent-analyst`, and `/qluent:investigate` so the orchestrator dispatches them with the correct expectation (one triangulated answer, not three reports).

## Decisions per agent (per #31 acceptance criteria)

| Agent | Decision | Leverage win |
|---|---|---|
| `trend-interpreter` | **deepen** | Multi-grain anomaly overlay returns a single one-off-vs-sustained verdict — the orchestrator cannot get this from one `qluent trees trend` call. |
| `rca-validator` | **deepen** | RCA + trend + companion compare, same windows, in one pass — multi-source synthesis no single bundled call delivers. |
| `segment-explorer` | **deepen** | Owns the unsupported-cut fallback: detects, picks a companion via cached catalog, runs and synthesizes — no caller-side stitching. |

## Test plan

- [ ] Manually invoke each agent against a real `qluent` CLI session and verify the verdicts match the underlying deterministic JSON.
- [ ] Confirm `trend-interpreter` runs both grains and reconciles when one grain has fewer periods than requested.
- [ ] Confirm `rca-validator` selects a sensible companion via `/tmp/qluent-tree-capabilities.json` when one isn't passed in.
- [ ] Confirm `segment-explorer` falls through gracefully when the catalog has no compatible tree.

Closes #31

https://claude.ai/code/session_01LyXPvVhqb91YgPxSeCaoKt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyXPvVhqb91YgPxSeCaoKt)_