### PR TITLE
Wire qluent-interpretation skill into slash commands (#32)

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -63,6 +63,8 @@ The bundled commands preserve deterministic server analysis and cost consent.
 
 ## Deterministic tree-query protocol
 
+The canonical Module is `skills/qluent-interpretation/SKILL.md`. Qluent slash commands `Read` it at the top of their workflow, and qluent agents load it via `skills:` frontmatter. Treat the bullets below as a contract reminder; the skill is normative.
+
 All metric values, deltas, decompositions, segment rankings, elasticity estimates, and recommendations based on numbers must be grounded in deterministic qluent JSON.
 
 - Resolve tree context before querying. If the user asks a question, use session tree context or `qluent trees list --json-output` and pass an explicit tree id.

--- a/plugins/qluent/commands/compare.md
+++ b/plugins/qluent/commands/compare.md
@@ -1,13 +1,19 @@
 ---
 description: Compare two metric trees side-by-side to validate the mechanism behind a change
 argument-hint: "[tree1] [tree2] [--period 'last week' | --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+allowed-tools: Bash(qluent *), Read
 disable-model-invocation: true
 ---
 
 # Compare metric trees
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
+
+Before running the compare, `Read` the canonical interpretation Module so the deterministic-query protocol and mechanism-decomposition rules are in context:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
 
 If `$ARGUMENTS` looks like a question rather than two tree ids, run `qluent trees list --json-output`, pick the two most relevant trees from the list (match against tree label, child node labels, and declared dimensions), and re-run with those tree ids.
 

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -14,6 +14,18 @@ This command is opt-in and can be expensive: it runs investigations across all t
 parallel through the deterministic qluent CLI. Do not run it from SessionStart or as an
 implicit first step.
 
+## Step 0: Load the canonical interpretation protocol
+
+Before running the deep dive, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
+
+It is the single source of truth for the deterministic-query protocol, evidence labels,
+elasticity guardrails, and unsupported-cut fallback. The cross-tree synthesis steps below
+sit on top of that contract.
+
 ## Step 1: Check CLI availability and capability
 
 Verify qluent is installed:

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -10,6 +10,16 @@ This is the primary entry point for all metric analysis. It bundles validation, 
 
 The qluent server is deterministic — it does NOT match natural-language questions to trees. YOU pick which tree to analyze when the user asks a question, by listing trees and matching against their metadata.
 
+## Step 0: Load the canonical interpretation protocol
+
+Before proceeding, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
+
+It is the single source of truth for the deterministic-query protocol, evidence labels, elasticity guardrails, and the unsupported-cut fallback rule. The summary below is a contract reminder; the skill is normative.
+
 ## Deterministic query contract
 
 - Resolve tree context before analysis. Do not let natural language stand in for a tree id.

--- a/plugins/qluent/commands/rca.md
+++ b/plugins/qluent/commands/rca.md
@@ -1,7 +1,7 @@
 ---
 description: Run standalone deterministic root cause analysis on a metric tree
 argument-hint: "[tree-name] [--period 'last week' | --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+allowed-tools: Bash(qluent *), Read
 disable-model-invocation: true
 ---
 
@@ -10,6 +10,16 @@ disable-model-invocation: true
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
 
 If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id. If no tree is a clear fit, ask the user to choose from the top candidates. Quantitative RCA claims require returned `qluent rca analyze` JSON for the selected tree/window.
+
+## Step 0: Load the canonical interpretation protocol
+
+Before running RCA, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
+
+It is the single source of truth for the deterministic-query protocol, evidence labels, and elasticity guardrails. The steps below are a workflow on top of that contract — the skill itself is normative.
 
 ## Step 1: Resolve tree and window deterministically
 

--- a/plugins/qluent/commands/trend.md
+++ b/plugins/qluent/commands/trend.md
@@ -1,13 +1,19 @@
 ---
 description: Run multi-period trend analysis for a metric tree
 argument-hint: "[tree-name] [--periods 4] [--grain week|month] [--as-of YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+allowed-tools: Bash(qluent *), Read
 disable-model-invocation: true
 ---
 
 # Trend analysis
 
 Use this as a follow-up after `/qluent:investigate`, not as a starting point.
+
+Before running trend analysis, `Read` the canonical interpretation Module so the deterministic-query protocol, trend label semantics, and anomaly-flag handling are in context:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
 
 If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id.
 

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qluent-interpretation
-description: Internal reference for interpreting qluent CLI output — Shapley attribution, trend labels, RCA confidence scores
-user-invocable: false
+description: Canonical protocol for interpreting qluent CLI output — deterministic-query rules, Shapley attribution, trend labels, RCA confidence/evidence coverage, elasticity guardrails, and unsupported-cut fallback. Loaded automatically by qluent agents via `skills:` frontmatter and explicitly by qluent slash commands.
+user-invocable: true
 ---
 
 # Interpreting qluent results


### PR DESCRIPTION
## Summary

Slash commands previously had no way to load the canonical interpretation Module — agents could pull it via `skills:` frontmatter, but `/qluent:investigate` and friends ran with only inline prose pointers, leaving the deepest Module in the plugin unreachable from its primary callers.

- Each qluent slash command now `Read`s `${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md` at the top of its workflow (Step 0 on `investigate`/`rca`/`deep-dive`, inline preface on `trend`/`compare`).
- `Read` is added to `allowed-tools` on the commands that lacked it (`trend`, `rca`, `compare`).
- The skill is flipped to `user-invocable: true` so a user (or an orchestrator debugging a workflow) can surface it directly via `/qluent:qluent-interpretation`.
- `CLAUDE.md` now points at the skill as the canonical Module so the local protocol prose is treated as a contract reminder, not a parallel source of truth.

This is option 3 from the issue (explicit Read step) combined with option 1 (flip user-invocable). Option 2 (frontmatter file include) wasn't pursued because Claude Code commands don't have a documented mechanism for inlining file contents at command-load time; an explicit `Read` is unambiguous, works today, and the skill remains the single source of truth.

## Test plan

- [ ] Run `/qluent:investigate` and confirm the model reads the skill before the deterministic-query contract bullets.
- [ ] Repeat for `/qluent:rca`, `/qluent:trend`, `/qluent:compare`, `/qluent:deep-dive`.
- [ ] Confirm `/qluent:qluent-interpretation` (or the equivalent surface for a user-invocable skill) surfaces the protocol on demand.

Closes #32

https://claude.ai/code/session_01LyXPvVhqb91YgPxSeCaoKt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyXPvVhqb91YgPxSeCaoKt)_