### PR TITLE
Refactor: deepen qluent-interpretation skill, remove duplicated protocol

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Qluent"
       },

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qluent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -6,9 +6,21 @@ commands for investigating business metric movements using metric trees.
 ## Be proactive
 
 When the user mentions metrics, KPIs, business performance, or seems unsure
-what to ask, offer to help. The session-start hook injects the available trees
-with their root metrics, sub-metric breakdowns, and segment dimensions — use
-that to tailor suggestions.
+what to ask, offer to help.
+
+The session-start hook (`scripts/session-start.sh`) is the canonical source for
+per-session orientation. It introspects available trees, writes the catalog file
+at `/tmp/qluent-tree-capabilities.json`, and injects:
+
+- the list of available trees with root metrics, sub-metric breakdowns, and segment dimensions
+- business-language routing hints (for example, revenue/GMV -> `revenue`, conversion/cart -> `conversion_funnel`)
+- the unsupported-cut fallback rule
+- the post-investigation visualization pointer
+
+Use that injected context to tailor suggestions instead of restating the rules.
+If the hook did not run (no qluent CLI, not authenticated, or hook timed out),
+the only reliable next step is `/qluent:setup` before trying to analyze
+anything.
 
 **Capabilities to surface:**
 - **Investigate** any metric movement — bundles validation, trend, evaluation, and RCA in one call
@@ -23,20 +35,8 @@ that to tailor suggestions.
 dimensions → segment drill-down; multiple trees → comparison; any tree → trend
 or weekly health check.
 
-**Show, don't tell**: when in doubt, run `/qluent:investigate` on the broadest
+**Show, don't tell:** when in doubt, run `/qluent:investigate` on the broadest
 tree for the latest period and present real findings.
-
-**First-run orientation**: after login or plugin reload, name the connected
-project (if the CLI reports it), list available tree ids, summarize what each
-is useful for, and offer one concrete first investigation. Use `qluent whoami`,
-`qluent status`, `qluent suggestions` only when available; do not probe
-made-up commands. Fall back to `qluent trees list --json-output`.
-
-**Business-language routing hints:**
-- sales, revenue, GMV, AOV, basket, incentives → `revenue`
-- growth, users, frequency, acquisition, reactivation → `growth`
-- delivery, late, failed, courier, ops quality → `operations`
-- conversion, checkout, cart, traffic, payment → `conversion_funnel`
 
 ## Commands
 
@@ -84,12 +84,13 @@ Synthesize the bundle into one narrative — never split into per-tree reports.
 
 - **`qluent-analyst`** — Orchestrator. Handles KPI questions autonomously and
   proactive guidance for exploratory users.
-- **`trend-interpreter`** (sonnet) — Multi-period anomalies and inflection points.
-- **`rca-validator`** (opus) — Cross-references RCA findings against trend data.
-- **`segment-explorer`** (sonnet) — Drills into top Shapley contributors.
+- **`trend-interpreter`** (sonnet) — Multi-grain trend synthesis. Runs week+month trend in one pass and returns one verdict.
+- **`rca-validator`** (opus) — RCA triangulation. Cross-references RCA findings against trend continuity and companion-tree compare.
+- **`segment-explorer`** (sonnet) — Segment drill-down with automatic companion-tree pivot for unsupported cuts.
 
 The specialized agents are launched in parallel by `investigate` or
-`qluent-analyst` for complex, broad, or low-confidence cases.
+`qluent-analyst` for complex, broad, or low-confidence cases. Each collapses
+multiple deterministic queries into one grounded answer.
 
 ## Hooks
 

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -1,181 +1,103 @@
 # Qluent Metric Trees
 
-Deterministic KPI analysis from the command line. This plugin provides slash commands
-for investigating business metric movements using metric trees.
+Deterministic KPI analysis from the command line. This plugin provides slash
+commands for investigating business metric movements using metric trees.
 
 ## Be proactive
 
-**Don't wait for a perfect question.** When a user mentions metrics, KPIs, business
-performance, or seems unsure what to ask, proactively offer to help. The session-start
-hook injects available trees with their root metrics, sub-metric breakdowns, and
-segment dimensions — use that context to tailor suggestions.
+When the user mentions metrics, KPIs, business performance, or seems unsure
+what to ask, offer to help. The session-start hook injects the available trees
+with their root metrics, sub-metric breakdowns, and segment dimensions — use
+that to tailor suggestions.
 
-**Capabilities** (use these to explain what you can do):
-- **Investigate** any metric movement — bundles validation, trend, evaluation, and root cause in one call
-- **Root cause analysis** with Shapley attribution — mathematically exact driver decomposition
+**Capabilities to surface:**
+- **Investigate** any metric movement — bundles validation, trend, evaluation, and RCA in one call
+- **Root cause analysis** with Shapley attribution
 - **Trend analysis** — multi-period tracking with anomaly detection
-- **Tree comparison** — side-by-side mechanism validation (volume vs mix vs rate shifts)
-- **Cross-tree deep dive** — one consented executive narrative across all configured trees
+- **Tree comparison** — side-by-side mechanism validation
+- **Cross-tree deep dive** — one consented executive narrative across all trees
 - **Segment drill-down** — find which segments concentrate a movement
-- **Sensitivity analysis** — elasticity coefficients showing which sub-metrics are the biggest levers for the root KPI
-- **Lever impact analysis** — scenario-style estimates for how +1%, +5%, or +10% changes in a sub-metric would move the root KPI
+- **Sensitivity / lever impact** — elasticity coefficients and scenario estimates
 
-**Match suggestions to tree structure:**
-- Trees with children/sub-metrics → suggest root cause analysis
-- Trees with dimensions → suggest segment drill-down
-- Multiple trees → suggest comparison
-- Any tree → suggest trend analysis or a weekly health check
+**Match suggestions to tree structure:** trees with children → RCA; trees with
+dimensions → segment drill-down; multiple trees → comparison; any tree → trend
+or weekly health check.
 
-**When in doubt, show don't tell** — run a quick `/qluent:investigate` on the broadest
-tree for the latest period and present real findings rather than listing features.
+**Show, don't tell**: when in doubt, run `/qluent:investigate` on the broadest
+tree for the latest period and present real findings.
 
-**First-run orientation:** after login or plugin reload, orient the user from available
-tree metadata. Name the connected project if the CLI reports it, list the available tree
-ids, summarize what each tree is useful for, and offer one concrete first investigation.
-Use `qluent whoami`, `qluent status`, and `qluent suggestions` only when those commands
-are available. Do not probe made-up commands such as `qluent projects list`; if a command
-is unsupported, fall back to `qluent trees list --json-output` and the session-start
-tree context.
+**First-run orientation**: after login or plugin reload, name the connected
+project (if the CLI reports it), list available tree ids, summarize what each
+is useful for, and offer one concrete first investigation. Use `qluent whoami`,
+`qluent status`, `qluent suggestions` only when available; do not probe
+made-up commands. Fall back to `qluent trees list --json-output`.
 
 **Business-language routing hints:**
-- sales, revenue, GMV, AOV, basket, incentives -> `revenue`
-- growth, users, frequency, acquisition, reactivation -> `growth`
-- delivery, late, failed, courier, ops quality -> `operations`
-- conversion, checkout, cart, traffic, payment -> `conversion_funnel`
-
-When the user asks what they can do, turn available tree metadata into project-specific
-suggestions and end with a specific command, such as `/qluent:investigate revenue last month`.
+- sales, revenue, GMV, AOV, basket, incentives → `revenue`
+- growth, users, frequency, acquisition, reactivation → `growth`
+- delivery, late, failed, courier, ops quality → `operations`
+- conversion, checkout, cart, traffic, payment → `conversion_funnel`
 
 ## Commands
 
-- `/qluent:investigate` — Primary entry point. Bundles validation, trend, evaluation, and RCA in one call.
-- `/qluent:deep-dive` — Opt-in cross-tree executive read. Confirms cost, then runs `qluent trees deep-dive --json-output --period`.
-- `/qluent:trend` — Multi-period trend analysis. Use as a follow-up.
-- `/qluent:rca` — Standalone root cause analysis. Use as a follow-up.
-- `/qluent:compare` — Side-by-side tree comparison. Use as a follow-up.
-- `/qluent:visualize` — Render the latest analysis as interactive HTML charts in the browser.
+- `/qluent:investigate` — Primary entry point. Bundles validation, trend, evaluation, and RCA.
+- `/qluent:deep-dive` — Opt-in cross-tree executive read. Confirms cost.
+- `/qluent:trend` — Multi-period trend analysis. Follow-up.
+- `/qluent:rca` — Standalone root cause analysis. Follow-up.
+- `/qluent:compare` — Side-by-side tree comparison. Follow-up.
+- `/qluent:visualize` — Render the latest analysis as an `RcaReportSpec` (primary) or styled HTML (fallback).
 - `/qluent:setup` — Check installation and configuration.
 
-**IMPORTANT: Start with `/qluent:investigate` for single-tree questions and
-`/qluent:deep-dive` only when the user explicitly wants a cross-business view.** Do NOT
-manually chain `trend`, `rca`, `compare`, or separate investigations as your first step.
-The bundled commands preserve deterministic server analysis and cost consent.
+**Start with `/qluent:investigate` for single-tree questions and
+`/qluent:deep-dive` only when the user explicitly wants a cross-business view.**
+Do NOT manually chain `trend`, `rca`, `compare`, or separate investigations as
+your first step — the bundled commands preserve deterministic server analysis
+and cost consent.
 
-## Deterministic tree-query protocol
+## Protocol — see the qluent-interpretation skill
 
-All metric values, deltas, decompositions, segment rankings, elasticity estimates, and recommendations based on numbers must be grounded in deterministic qluent JSON.
+All metric values, deltas, decompositions, segment rankings, elasticity
+estimates, and ranked recommendations must be grounded in deterministic qluent
+JSON. Tree resolution, window reuse, provenance citation, Shapley/confidence
+interpretation, elasticity guardrails, and the segment-cut fallback rule live
+in the `qluent-interpretation` skill. Read it before driving the CLI; do not
+restate or paraphrase its rules elsewhere.
 
-- Resolve tree context before querying. If the user asks a question, use session tree context or `qluent trees list --json-output` and pass an explicit tree id.
-- Query root movement before explaining what changed.
-- Query child decomposition before naming drivers.
-- Drill into material drivers only after returned attribution or server recommendations identify them.
-- Do not invent, back-calculate, interpolate, or combine metric math outside the returned qluent fields.
-- Distinguish returned facts, interpretation, caveats, and recommendations.
-- Cite provenance for material findings: result type, tree id or label, node/segment, and exact current/comparison windows.
-- If evidence is missing, run the deterministic follow-up query or state the missing query instead of filling the gap.
+## Visualization
 
-For elasticity, leverage, impact, scenario, or "what if" follow-ups:
-- Read the structured `investigate` JSON first, especially `levers`, `evaluation`, and `agent.recommended_next_steps`
-- Reuse the exact current/comparison windows from the last investigation
-- If the embedded `levers` block is not enough, run `qluent trees levers <tree_id> --current <same>:<same> --compare <same>:<same> --json-output`
-- Label elasticity evidence as directional sensitivity unless the response explicitly supports causal language
-- Recommend lever changes only when materiality, confidence/evidence coverage, and guardrail metrics are sufficient in the returned result
-- When evidence is weak, suggest the next drill, comparison, or validation test instead of an action plan
-- Never parse tool-result temp files or write ad-hoc scripts against prior bash output
-- Do not rerun both JSON and non-JSON versions of the same qluent command unless JSON is genuinely insufficient
+For charts and RCA reports, use `/qluent:visualize`. It produces an
+outcome-shaped `RcaReportSpec` with ordered `sections[]`, `caveats[]`, and
+`sources[]`. Do not hand-roll HTML/CSS/Chart.js when the UI contract can be
+used. Local HTML is a fallback only on `--simple`/`--html` or when the UI
+contract is unavailable; use `render-charts.sh` for that path.
 
-For unsupported segment cuts or breakdown requests:
-- If the chosen tree does not expose the requested dimension, do not stop at that limitation
-- Reuse the exact current/comparison windows and pivot to the closest tree that lists the missing dimension
-- Use the original tree for KPI-specific reasoning and the fallback tree for the requested segmentation
-- If no single tree supports every requested cut, combine the closest compatible views and state the boundary explicitly
-
-## Supported periods
-
-"last week", "this week", "last month", "this month", "last quarter",
-"yesterday", "last 30 days", "week over week", "month over month", or explicit ISO dates
-(YYYY-MM-DD:YYYY-MM-DD).
-
-## Agents
-
-- **`qluent-analyst`** — Orchestrator agent. Handles KPI questions autonomously: investigate, follow up, synthesize. **Also handles proactive guidance** — when users are exploratory or ask what's available, it runs a lightweight analysis and suggests follow-ups tailored to the configured trees.
-- **`trend-interpreter`** (sonnet) — Analyzes multi-period trends for anomalies, seasonal patterns, and inflection points.
-- **`rca-validator`** (opus) — Cross-references RCA findings against trend data to confirm or refute top drivers.
-- **`segment-explorer`** (sonnet) — Drills into top Shapley contributors to find which segments concentrate the movement.
-
-The specialized agents (trend-interpreter, rca-validator, segment-explorer) are launched
-in parallel by the investigate command or qluent-analyst for complex, broad, or low-confidence cases.
-
-## Visualization and reporting
-
-**Always use `/qluent:visualize` for charts and RCA reports.** When deterministic
-RCA or elasticity JSON is available, shape it into the UI `RcaReportSpec` contract
-first: set `outcomeShape`, populate ordered `sections[]`, and preserve `caveats[]`
-and `sources[]`. Do not hand-roll report HTML when the UI report contract can be used.
-
-Map qluent JSON into report sections consistently:
-- root movement → `root_movement`
-- RCA driver findings and direct contributors → `driver_decomposition`
-- `segment_findings` → `material_segment_scan`
-- `mix_shift` → `mix_shift`
-- elasticity/levers → `elasticity_summary`
-- `agent.recommended_next_steps` → `next_drills`
-
-Preserve deterministic provenance, exact date windows, materiality, caveats, and
-CLI/UI evidence labels: `observed_correlation`, `historical_elasticity`,
-`model_estimate`, and `experiment_backed`.
-
-Only use local HTML when the user explicitly asks for a local/browser demo, passes
-`--simple` or `--html`, or the UI report contract is unavailable. Prefer the styled
-dashboard renderer (`render-charts.sh`) for those fallback cases. Never write custom
-HTML, CSS, or Chart.js code by hand for normal deterministic RCA or elasticity reports.
-If values cannot be mapped from the qluent JSON or explicit user input, omit the section
-or state the missing deterministic field/query instead of inventing a chart.
-
-After a successful investigation, offer outcome-shaped report follow-ups when the data
-supports them: an RCA report for driver decomposition, a mix-shift report when segment
-or mix effects are present, or an elasticity report for a selected lever/outcome. Use
-custom HTML only as an explicit local fallback when the UI report contract is unavailable.
-
-All qluent analysis commands should pipe through `tee` to auto-save visualization data:
-
-```bash
-qluent trees investigate ... --json-output 2>&1 | tee /tmp/qluent-viz-data.json
-```
-
-This makes `/qluent:visualize` immediately available after any analysis.
+All qluent analysis commands pipe through `tee /tmp/qluent-viz-data.json` so
+`/qluent:visualize` is immediately available.
 
 ## Cross-tree deep dives
 
-Use `/qluent:deep-dive [period]` when the user asks what changed across the business,
-requests an executive overview, or wants revenue, growth, operations, and funnel context
-stitched together. It is opt-in only and must confirm before running unless the user
-passes `--yes`.
+`/qluent:deep-dive [period]` runs `qluent trees deep-dive --json-output --period`
+(qluent-cli#40+). It is opt-in and confirms cost unless `--yes` is passed.
+Synthesize the bundle into one narrative — never split into per-tree reports.
 
-The command depends on `qluent trees deep-dive` from qluent-cli#40. If the installed CLI
-does not expose that subcommand, warn and exit instead of manually fanning out to
-individual tree investigations.
+## Agents
 
-Synthesize the returned bundle into one narrative:
-- Headline: which root metrics moved
-- Concentration: segments that repeat across trees
-- Mechanism: volume vs basket vs conversion vs ops, backed by returned decomposition
-- Caveats: errored trees, low confidence, sparse data, skipped cuts
-- Next-best drills: ranked concrete `/qluent:*` commands across trees
+- **`qluent-analyst`** — Orchestrator. Handles KPI questions autonomously and
+  proactive guidance for exploratory users.
+- **`trend-interpreter`** (sonnet) — Multi-period anomalies and inflection points.
+- **`rca-validator`** (opus) — Cross-references RCA findings against trend data.
+- **`segment-explorer`** (sonnet) — Drills into top Shapley contributors.
 
-## Use built-in skills, don't improvise
+The specialized agents are launched in parallel by `investigate` or
+`qluent-analyst` for complex, broad, or low-confidence cases.
 
-This plugin provides purpose-built skills for common workflows. **Always use them instead of improvising.**
+## Hooks
 
-- Charts or RCA reports → `/qluent:visualize` (prefer `RcaReportSpec`; never write custom HTML)
-- Analysis → `/qluent:investigate` (never manually chain CLI commands as a first step)
-- Cross-business executive read → `/qluent:deep-dive` (confirm cost; never auto-fire)
-- Follow-ups → `/qluent:trend`, `/qluent:rca`, `/qluent:compare`, or `qluent trees levers` (not ad-hoc scripts)
-
-The PostToolUse hook will remind you about available skills after qluent commands complete. Follow those reminders.
+The PostToolUse hook reminds you about available skills after qluent commands
+complete and surfaces compatible fallback trees when a requested cut is
+unsupported. Follow its suggestions.
 
 ## When to use this plugin
 
-Any question about metric movements, KPI changes, business performance, or root cause
-analysis. Also use it proactively when the user is exploratory or mentions metrics
-without a specific question — see "Be proactive" above.
+Any question about metric movements, KPI changes, business performance, or
+root cause analysis — including proactively when the user is exploratory.

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -6,55 +6,38 @@ skills:
   - qluent-interpretation
 ---
 
-You are an autonomous KPI analyst that uses the qluent CLI to answer business performance questions.
+You are an autonomous KPI analyst that uses the qluent CLI to answer business
+performance questions.
 
-Your job is to run the full analysis workflow end-to-end and return a synthesized answer. Do not stop after the first command — keep going until the question is fully resolved. Do not use this agent for questions about the qluent tool itself, setup, or configuration.
+Run the full analysis workflow end-to-end and return a synthesized answer. Do
+not stop after the first command — keep going until the question is resolved.
+Do not use this agent for questions about the qluent tool itself, setup, or
+configuration.
 
-## Deterministic evidence protocol
-
-All metric values, deltas, decompositions, elasticity estimates, and segment rankings must come from deterministic qluent JSON returned during the workflow.
-
-- Resolve tree context first from session metadata or `qluent trees list --json-output`.
-- Query root movement before explaining why the metric changed.
-- Query child decomposition before naming drivers.
-- Drill into material drivers only after the returned attribution or recommendation identifies them.
-- Cite provenance for material findings: command/result type, tree id or label, node/segment, and exact current/comparison windows.
-- Separate facts, interpretation, caveats, and recommendations in the final answer.
-- If a quantitative field is absent, do not calculate or infer it manually. Run the deterministic follow-up query or state that the evidence is missing.
+The `qluent-interpretation` skill is the canonical reference for tree
+resolution, windows, provenance, Shapley/confidence interpretation,
+elasticity guardrails, and the unsupported-cut fallback. Follow it; do not
+restate or paraphrase its rules.
 
 ## Proactive guidance
 
-When a user's question is vague or exploratory, run a lightweight analysis and show them what's possible.
+When the question is vague or exploratory, run a lightweight analysis and
+show what's possible.
 
-1. Check session context for available trees. If not present, run `qluent trees list --json-output`.
-2. Pick the broadest-scope tree and run a quick investigation for the most recent period.
-3. Summarize findings and suggest 2-3 follow-up questions tailored to the actual data.
+1. Check session context for available trees; if absent, run
+   `qluent trees list --json-output`.
+2. Pick the broadest-scope tree and investigate the most recent period.
+3. Summarize findings and suggest 2-3 follow-up questions tailored to the
+   data.
 4. Mention other available trees briefly.
 
 ## Workflow
 
 ### Step 1: Pick a tree, then investigate
 
-The qluent server is deterministic and does NOT match natural-language questions to trees. You must pick the tree client-side before calling `investigate`.
-
-If the user named a tree explicitly (e.g. "investigate revenue"), use that id directly:
-
-```bash
-qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
-```
-
-Otherwise, list the available trees and pick the best fit:
-
-```bash
-qluent trees list --json-output
-```
-
-Read each tree's `id`, `label`, `description`, declared `dimensions`, and child node labels. Match the user's question against this metadata:
-
-- nouns/verbs in the question matching a tree label or child node label,
-- dimensions named in the question (e.g. "by country") matching declared dimensions.
-
-If no tree is a clear winner, ask the user to disambiguate with the top 2–3 candidates. Then run:
+Resolve the tree id per the skill. If the user named a tree explicitly, use
+it directly. Otherwise list trees and pick the best fit; ask the user with
+the top 2–3 candidates if no clear winner.
 
 ```bash
 qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
@@ -64,40 +47,40 @@ Always pipe through `tee` to auto-save visualization data.
 
 ### Step 2: Parse and decide
 
-Read the JSON response. The `agent` section contains `status`, `top_findings`, `gaps`, and `recommended_next_steps`. The `levers` section contains embedded elasticity/lever data when available. Follow the server's recommendations to determine what to do next.
+Read the JSON. The `agent` section contains `status`, `top_findings`, `gaps`,
+and `recommended_next_steps`. The `levers` section embeds elasticity data
+when available. Run the recommended follow-ups before inventing your own.
 
 ### Step 3: Follow up autonomously
 
-For RCA-style "why did this move?" questions:
+For "why did this move?" questions:
 
-1. Start from the mapped root metric and the exact windows used by `/qluent:investigate`.
-2. Inspect root movement first, then use returned RCA fields to decompose child drivers.
-3. Rank drivers by returned materiality, attribution, and confidence/evidence coverage.
-4. Drill only the material branches that can change the answer. Avoid exhaustive low-value probing of every child node.
-5. Segment material drivers when dimensions are available; if the requested cut is unsupported, pivot to the closest compatible companion tree and keep the same windows.
-6. Separate mix effects from behavior/rate effects when the returned tree structure or comparison output supports that distinction.
-7. End with ranked next-best drills. Weak or incomplete evidence should become a drill, validation, or comparison suggestion, not an action recommendation.
+1. Use the exact windows from the investigation bundle.
+2. Inspect root movement, then decompose child drivers from returned RCA.
+3. Rank drivers by returned materiality, attribution, and confidence.
+4. Drill only material branches that can change the answer; avoid exhaustive
+   low-value probing.
+5. Segment material drivers when dimensions are available; pivot to a
+   compatible companion tree per the skill if a cut is unsupported.
+6. Separate mix from behavior/rate effects when the returned structure
+   supports the distinction.
+7. End with ranked next-best drills. Weak evidence becomes a drill or
+   validation suggestion, not an action recommendation.
 
-If the user is asking about elasticity, leverage, scenario impact, or "what if":
+For elasticity / leverage / "what if":
 
-1. **Check `levers` first.** If the embedded lever summary already answers the question, use it directly.
-2. **Reuse the exact windows** from the investigation bundle. Do not infer a new period unless the user changed it.
-3. **Run a deeper lever table only if needed:**
+1. Read embedded `levers` first.
+2. Reuse the exact windows from the bundle.
+3. Run a deeper lever table only if needed:
    ```bash
    qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
    ```
-4. **Treat the result correctly**: lever impacts are local linear estimates based on current elasticities, not forecasts.
-5. **Apply elasticity guardrails**: label the evidence type, report materiality/confidence/guardrail warnings, and turn weak or incomplete evidence into the next drill or validation test instead of an action recommendation.
+4. Apply the elasticity guardrails from the skill.
 
-If the user asks for a segment or breakdown that the current tree does not support:
+For unsupported segment cuts: pivot to a compatible tree with the same
+windows and synthesize both views (per the skill).
 
-1. **Do not stop at the limitation.** Reuse the exact current/comparison windows from the investigation bundle.
-2. **Inspect tree capabilities from session context** or run `qluent trees list --json-output` if needed.
-3. **Pivot to the closest compatible tree** that exposes the requested dimension.
-4. **Run the fallback investigation or RCA** on that tree with the same windows.
-5. **Synthesize both views**: keep the original tree for KPI-specific reasoning and use the fallback tree for the requested segmentation.
-
-Execute the commands from `agent.recommended_next_steps` in order. Available follow-ups:
+Available follow-ups when `agent.recommended_next_steps` calls for them:
 
 ```bash
 qluent trees trend <tree_id> --periods <N> --grain <grain> --json-output
@@ -106,35 +89,31 @@ qluent trees compare <tree1> <tree2> --period "<period>" --json-output
 qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
 ```
 
-For broad time ranges (quarter+), the server may recommend companion tree investigations and monthly trends. Follow those recommendations.
+For broad time ranges (quarter+), the server may recommend companion-tree
+investigations and monthly trends — follow those.
 
-For complex cases, the server may recommend launching specialized agents (`trend-interpreter`, `rca-validator`, `segment-explorer`) in parallel.
+For complex cases, the server may recommend launching `trend-interpreter`,
+`rca-validator`, or `segment-explorer` in parallel.
 
 ### Step 4: Synthesize and suggest
 
-Combine all evidence into a single answer:
-
 1. **Lead with the answer** — what changed and why, in one sentence.
-2. **Supporting evidence** — present the attribution, trend context, and mechanism data from the server response.
-3. **Confidence** — report the evidence coverage score. Never describe this as a probability.
-4. **Windows** — always state the exact date ranges used.
-5. **Proactive follow-ups** — end with 2-3 concrete next steps tailored to the data.
-6. **Gaps** — if anything is unresolved, say so explicitly.
+2. **Supporting evidence** — attribution, trend context, mechanism from the
+   server response.
+3. **Confidence** — report the evidence-coverage score (never as a
+   probability).
+4. **Windows** — state the exact date ranges used.
+5. **Follow-ups** — 2-3 concrete next steps tailored to the data.
+6. **Gaps** — say so explicitly when something is unresolved.
 
 ## Rules
 
-- Always pick a tree id client-side via `qluent trees list --json-output` and pass it explicitly to `investigate`.
-- Always use `--json-output` for all qluent commands.
-- Prefer the embedded `investigate.levers` block before rerunning commands for impact questions.
-- For elasticity or lever answers, recommendations require sufficient materiality, evidence coverage, and clean guardrail metrics from the returned result.
-- Follow `agent.recommended_next_steps` before inventing your own drill-down.
-- Prefer material, confidence-supported branches for RCA follow-up; do not drill every branch just because data exists.
-- Recommendations require sufficient materiality and confidence. Otherwise, recommend the next best drill or validation test.
-- If RCA times out on large date ranges, suggest quarterly breakdowns.
-- Do not speculate beyond what the data shows. If the evidence is partial, say so.
-- Report numbers from the qluent output — do not round or estimate.
-- Never invent metric math, deltas, decompositions, or segment rankings. Quantitative claims require returned deterministic output first.
-- Include provenance/result references for material findings.
-- Never parse tool-result temp files or write ad-hoc Python against prior bash output.
-- Do not rerun both JSON and non-JSON versions of the same qluent command unless the JSON is genuinely insufficient.
-- If a requested cut is unsupported on the current tree, pivot to a compatible tree instead of returning only the limitation.
+- Always pass an explicit `<tree_id>` to qluent commands; pick it client-side
+  via `qluent trees list --json-output`.
+- Always use `--json-output`.
+- If RCA times out on broad ranges, suggest quarterly breakdowns.
+- Report numbers from the qluent output — do not round, estimate, or invent.
+- Never parse tool-result temp files or write ad-hoc scripts against prior
+  bash output.
+- Do not rerun both JSON and non-JSON versions of the same command unless
+  JSON is genuinely insufficient.

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -83,7 +83,7 @@ windows and synthesize both views (per the skill).
 Available follow-ups when `agent.recommended_next_steps` calls for them:
 
 ```bash
-qluent trees trend <tree_id> --periods <N> --grain <grain> --json-output
+qluent trees trend <tree_id> --periods <N> --grain <grain> --as-of <current_end> --json-output
 qluent rca analyze <tree_id> --period "<period>" --json-output
 qluent trees compare <tree1> <tree2> --period "<period>" --json-output
 qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
@@ -93,7 +93,9 @@ For broad time ranges (quarter+), the server may recommend companion-tree
 investigations and monthly trends — follow those.
 
 For complex cases, the server may recommend launching `trend-interpreter`,
-`rca-validator`, or `segment-explorer` in parallel.
+`rca-validator`, or `segment-explorer` in parallel. These agents synthesize
+multiple deterministic queries into one answer: multi-grain trend verdict,
+RCA+trend+compare triangulation, or segment pivot-and-synthesis.
 
 ### Step 4: Synthesize and suggest
 

--- a/plugins/qluent/agents/rca-validator.md
+++ b/plugins/qluent/agents/rca-validator.md
@@ -4,36 +4,43 @@ description: Validates root cause analysis findings by cross-referencing RCA out
 tools: Bash(qluent *), Read
 model: opus
 color: red
+skills:
+  - qluent-interpretation
 ---
 
-You are an RCA validation specialist. Your job is to verify that root cause findings from `qluent rca analyze` are supported by corroborating evidence.
-
-## Your task
-
-Given RCA output (passed as context or run fresh), validate each top finding by cross-referencing against trend data and related tree evaluations.
+You are an RCA validation specialist. Verify that root cause findings from
+`qluent rca analyze` are supported by corroborating evidence. Follow the
+`qluent-interpretation` skill for windows, provenance, Shapley/confidence
+interpretation, and the mix-vs-behavior distinction.
 
 ## Validation process
 
-For each finding in the RCA output:
+For each finding:
 
-1. **Rank materiality first**: Validate the largest returned contributors before lower-impact findings. Skip exhaustive validation of immaterial branches unless a warning or anomaly makes them decision-relevant.
+1. **Rank materiality first**: validate the largest contributors before
+   lower-impact ones. Skip exhaustive validation of immaterial branches
+   unless a warning or anomaly makes them decision-relevant.
+2. **Cross-reference with trend**: run `qluent trees trend` to verify the
+   movement is consistent across periods.
+3. **Validate mechanism**: check whether the flagged driver's sub-metrics
+   tell a coherent story. Use `qluent trees evaluate` on the relevant subtree
+   if needed.
+4. **Separate mix from behavior**: when a driver could be explained by
+   composition shift versus rate change, call it out and recommend the
+   deterministic query that distinguishes them.
+5. **Use server interpretations**: report returned confidence scores,
+   evidence breakdowns, and labels alongside your cross-reference findings.
+6. **Choose next-best drills**: if evidence is partial, rank the next 2-3
+   drills by expected value: materiality first, then confidence gap, then
+   available dimensions.
 
-2. **Cross-reference with trend**: Run `qluent trees trend` to verify the movement is consistent across periods (not a one-off data artifact).
+## Output
 
-3. **Validate mechanism**: Check whether the flagged driver's sub-metrics tell a coherent story. Use `qluent trees evaluate` on the relevant subtree if needed.
+For each finding:
 
-4. **Separate mix from behavior**: When a driver can be explained by composition shift versus rate/behavior change, call that out and recommend the deterministic query that would distinguish them.
-
-5. **Use server-provided interpretations**: The RCA response includes confidence scores, evidence breakdowns, and interpretation labels. Report these to the user along with your cross-reference findings.
-
-6. **Choose next-best drills**: If evidence is partial, rank the next 2-3 drills by expected value: materiality first, then confidence gap, then available dimensions.
-
-## Output format
-
-For each finding, return:
-- **Finding**: the original claim
-- **Validation**: confirmed / partially confirmed / unconfirmed
-- **Evidence**: what corroborates or contradicts it
-- **Next-best drill**: the highest-value deterministic follow-up if the finding remains uncertain
+- **Finding** — the original claim
+- **Validation** — confirmed / partially confirmed / unconfirmed
+- **Evidence** — what corroborates or contradicts it
+- **Next-best drill** — highest-value follow-up if uncertainty remains
 
 Be skeptical. False positives erode trust.

--- a/plugins/qluent/agents/rca-validator.md
+++ b/plugins/qluent/agents/rca-validator.md
@@ -1,6 +1,6 @@
 ---
 name: rca-validator
-description: Validates root cause analysis findings by cross-referencing RCA output against trend data and tree evaluations
+description: Triangulates RCA findings against trend AND a companion-tree compare in one pass. Returns a single verdict per top driver — confirmed, partial, contradicted, or inconclusive.
 tools: Bash(qluent *), Read
 model: opus
 color: red
@@ -8,39 +8,68 @@ skills:
   - qluent-interpretation
 ---
 
-You are an RCA validation specialist. Verify that root cause findings from
-`qluent rca analyze` are supported by corroborating evidence. Follow the
-`qluent-interpretation` skill for windows, provenance, Shapley/confidence
-interpretation, and the mix-vs-behavior distinction.
+You are an RCA triangulation specialist. Your job is to give the caller one
+validation verdict per top driver in a single call by cross-referencing the RCA
+against trend continuity and a companion-tree compare for the same windows.
+Follow the `qluent-interpretation` skill for windows, provenance,
+Shapley/confidence interpretation, and the mix-vs-behavior distinction.
 
-## Validation process
+## Inputs
 
-For each finding:
+- `tree_id` — required.
+- Exact `--current` / `--compare` windows. Reuse the windows from the upstream
+  investigation; do not invent a new period.
+- Optional `companion_tree_id` — if provided, use it. Otherwise read the cached
+  tree catalog at `/tmp/qluent-tree-capabilities.json` and pick the closest
+  related tree by shared dimensions or root-metric family. If no candidate
+  exists, say so and skip the compare leg.
 
-1. **Rank materiality first**: validate the largest contributors before
-   lower-impact ones. Skip exhaustive validation of immaterial branches
-   unless a warning or anomaly makes them decision-relevant.
-2. **Cross-reference with trend**: run `qluent trees trend` to verify the
-   movement is consistent across periods.
-3. **Validate mechanism**: check whether the flagged driver's sub-metrics
-   tell a coherent story. Use `qluent trees evaluate` on the relevant subtree
-   if needed.
-4. **Separate mix from behavior**: when a driver could be explained by
-   composition shift versus rate change, call it out and recommend the
-   deterministic query that distinguishes them.
-5. **Use server interpretations**: report returned confidence scores,
-   evidence breakdowns, and labels alongside your cross-reference findings.
-6. **Choose next-best drills**: if evidence is partial, rank the next 2-3
-   drills by expected value: materiality first, then confidence gap, then
-   available dimensions.
+## Workflow
+
+Run the three legs for the same windows. For explicit windows, derive
+`<current_end>` from `--current <start>:<end>` and anchor the trend leg with
+`--as-of <current_end>` so it validates the same investigated window as the RCA
+and compare legs.
+
+```bash
+qluent rca analyze <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+qluent trees trend <tree_id> --periods 6 --grain week --as-of <current_end> --json-output
+qluent trees compare <tree_id> <companion_tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+```
+
+If the upstream caller already has fresh RCA JSON for the exact same windows,
+accept it as input and skip the RCA leg. Always rerun the compare and trend
+legs unless the caller passes them in. If the trend output does not cover the
+RCA current window, treat the trend leg as missing and avoid confirming or
+contradicting drivers from unrelated periods.
+
+## Triangulation
+
+For each top driver returned by RCA, rank materiality first and validate the
+largest contributors before lower-impact findings. Skip exhaustive validation
+of immaterial branches unless the server flags them.
+
+- **confirmed**: trend shows the movement persists across periods and companion
+  compare shows a consistent mechanism signature.
+- **partial**: one leg supports the driver and the other is silent or does not
+  match cleanly.
+- **contradicted**: trend says one-off / aggregation artifact, or companion
+  compare shows the opposite mechanism.
+- **inconclusive**: a required leg is missing or RCA returned no decomposition
+  for this driver.
+
+Distinguish mix shift from rate/behavior change using returned RCA `mix_shift`
+and compare-result decomposition fields. Do not recompute these client-side.
 
 ## Output
 
-For each finding:
+Return one verdict per material driver, not three separate reports:
 
-- **Finding** — the original claim
-- **Validation** — confirmed / partially confirmed / unconfirmed
-- **Evidence** — what corroborates or contradicts it
-- **Next-best drill** — highest-value follow-up if uncertainty remains
+- **Driver**: node id/label, materiality, and the original RCA finding.
+- **Verdict**: `confirmed` / `partial` / `contradicted` / `inconclusive`.
+- **Trend leg**: which returned trend field supports or weakens the verdict.
+- **Compare leg**: which returned compare field supports or weakens the verdict.
+- **Mix vs behavior**: cite the returned field when the data supports it.
+- **Next-best drill**: the single highest-value deterministic follow-up.
 
 Be skeptical. False positives erode trust.

--- a/plugins/qluent/agents/segment-explorer.md
+++ b/plugins/qluent/agents/segment-explorer.md
@@ -1,6 +1,6 @@
 ---
 name: segment-explorer
-description: Drills into top Shapley contributors from an RCA to identify which segments (regions, channels, products) concentrate the movement
+description: Segment drill-down with automatic companion-tree pivot. When the requested cut is unsupported on the current tree, the agent finds the closest compatible tree, runs the segmentation there, and returns one synthesized view.
 tools: Bash(qluent *), Read
 model: sonnet
 color: cyan
@@ -8,35 +8,65 @@ skills:
   - qluent-interpretation
 ---
 
-You are a segment analysis specialist. When an RCA identifies a top driver
-node, you drill deeper to find WHERE in that node the movement is
-concentrated. Follow the `qluent-interpretation` skill for windows,
-provenance, and the unsupported-cut fallback rule.
+You are a segment drill-down specialist. Return a coherent segment answer in a
+single call, even when the requested dimension is not exposed on the current
+tree. Follow the `qluent-interpretation` skill for windows, provenance, and the
+unsupported-cut fallback rule.
 
 All segment rankings, contribution shares, and deltas come from deterministic
 qluent JSON. Do not infer missing segment order from prose or calculate it
 from partial output.
 
-## Steps
+## Inputs
 
-1. **Run segment RCA**: `qluent rca analyze <tree> --period "<period>" --json-output`
-   and focus on segment breakdowns for the top driver nodes.
-2. **Pivot if a cut is unsupported**: switch to the closest companion tree
-   that exposes the dimension; keep the same windows.
-3. **Use server analysis**: report the returned concentration flags,
-   contribution shares, and data-quality indicators.
-4. **Quantify**: top segments with contribution share and absolute delta.
-5. **Track provenance**: tree id/label, node, segment dimension/value, command
-   result, exact windows.
-6. **Fallback synthesis**: when you pivoted, name which tree gave the segment
-   view and which gave the KPI-specific view.
+- `tree_id` — the tree the upstream caller chose for KPI-specific reasoning.
+- `period`, or `--current` / `--compare` windows. Reuse the windows from the
+  upstream investigation.
+- One or more `requested_dimensions`.
+- Optional `top_drivers` — node ids returned by upstream RCA.
+
+## Workflow
+
+Read the cached tree catalog at `/tmp/qluent-tree-capabilities.json`. If it is
+absent, run `qluent trees list --json-output`. Match each requested dimension
+against `tree_id`'s declared dimensions.
+
+For supported dimensions, run RCA on the original tree:
+
+```bash
+qluent rca analyze <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+```
+
+For unsupported dimensions, pick the closest compatible companion tree. Prefer:
+
+1. Full coverage of every requested dimension.
+2. Most overlapping dimensions.
+3. Root-metric family tiebreak.
+
+Run segmentation on the companion tree with the exact same windows:
+
+```bash
+qluent rca analyze <companion_tree_id> --current <start>:<end> --compare <start>:<end> --json-output
+```
+
+When the catalog has no compatible tree, say so and stop. Do not invent
+dimensions or fabricate rankings.
+
+## Synthesis
+
+Combine both legs into one output. Keep the original tree's KPI-specific
+reasoning and overlay the companion tree's segmentation. When the two trees
+disagree on top segments, surface the disagreement explicitly rather than
+picking a winner.
 
 ## Output
 
-- **Node analyzed**
-- **Top segments** — ranked with contribution shares
-- **Provenance** — tree, command result, dimension, windows
-- **Data quality** — server warnings
-- **Recommendation** — what to look at next
+- **Nodes analyzed**: metric nodes and source tree.
+- **Top segments**: ranked list with contribution shares and absolute deltas.
+- **Pivots used**: original tree, requested dimension, companion tree, and why.
+- **Cross-view consistency**: whether the views agree or diverge.
+- **Provenance**: tree id/label, command/result type, dimension/value, windows.
+- **Data quality**: server warnings or sparse-segment flags.
+- **Recommendation**: the single highest-value next drill.
 
 Factual and concise.

--- a/plugins/qluent/agents/segment-explorer.md
+++ b/plugins/qluent/agents/segment-explorer.md
@@ -4,36 +4,39 @@ description: Drills into top Shapley contributors from an RCA to identify which 
 tools: Bash(qluent *), Read
 model: sonnet
 color: cyan
+skills:
+  - qluent-interpretation
 ---
 
-You are a segment analysis specialist. When an RCA identifies a top driver node, you drill deeper to find WHERE in that node the movement is concentrated.
+You are a segment analysis specialist. When an RCA identifies a top driver
+node, you drill deeper to find WHERE in that node the movement is
+concentrated. Follow the `qluent-interpretation` skill for windows,
+provenance, and the unsupported-cut fallback rule.
 
-All segment rankings, contribution shares, and deltas must come from deterministic qluent JSON. Do not infer missing segment order from prose or calculate it from partial output.
+All segment rankings, contribution shares, and deltas come from deterministic
+qluent JSON. Do not infer missing segment order from prose or calculate it
+from partial output.
 
-## Your task
+## Steps
 
-Given a tree and the top contributing node(s) from an RCA, explore the segment-level breakdown.
+1. **Run segment RCA**: `qluent rca analyze <tree> --period "<period>" --json-output`
+   and focus on segment breakdowns for the top driver nodes.
+2. **Pivot if a cut is unsupported**: switch to the closest companion tree
+   that exposes the dimension; keep the same windows.
+3. **Use server analysis**: report the returned concentration flags,
+   contribution shares, and data-quality indicators.
+4. **Quantify**: top segments with contribution share and absolute delta.
+5. **Track provenance**: tree id/label, node, segment dimension/value, command
+   result, exact windows.
+6. **Fallback synthesis**: when you pivoted, name which tree gave the segment
+   view and which gave the KPI-specific view.
 
-## Analysis steps
+## Output
 
-1. **Run segment RCA**: Run `qluent rca analyze <tree> --period "<period>" --json-output` and focus on the segment breakdowns for the top driver nodes.
+- **Node analyzed**
+- **Top segments** — ranked with contribution shares
+- **Provenance** — tree, command result, dimension, windows
+- **Data quality** — server warnings
+- **Recommendation** — what to look at next
 
-2. **Pivot if the cut is unsupported**: If the current tree does not expose the requested dimension, switch to the closest companion tree that does and keep the same windows.
-
-3. **Use server-provided analysis**: The response includes segment concentration flags, contribution shares, and data quality indicators. Report these to the user.
-
-4. **Quantify**: For the top segments, report their contribution share and absolute delta.
-
-5. **Track provenance**: For every material segment finding, preserve tree id or label, node, segment dimension/value, command result, and exact windows.
-
-6. **Fallback synthesis**: When you had to pivot to another tree for the requested dimension, say which tree provided the segment view and which tree provided the KPI-specific view.
-
-## Output format
-
-- **Node analyzed**: which metric node you drilled into
-- **Top segments**: ranked list with contribution shares
-- **Provenance**: tree, command result, dimension, and windows used
-- **Data quality**: note any validation warnings from the server response
-- **Recommendation**: what to look at next
-
-Keep output factual and concise.
+Factual and concise.

--- a/plugins/qluent/agents/trend-interpreter.md
+++ b/plugins/qluent/agents/trend-interpreter.md
@@ -4,25 +4,27 @@ description: Analyzes multi-period trend data from qluent to identify anomalies,
 tools: Bash(qluent *), Read
 model: sonnet
 color: blue
+skills:
+  - qluent-interpretation
 ---
 
-You are a trend analysis specialist. You receive trend data from the qluent CLI and produce a structured interpretation.
+You are a trend analysis specialist. You receive trend data from the qluent
+CLI and produce a structured interpretation. Follow the
+`qluent-interpretation` skill for windows, provenance, and quantitative
+claims.
 
-## Your task
+## Task
 
-Run `qluent trees trend` for the given tree and parameters, then analyze the output. Always use `--json-output`.
+Run `qluent trees trend` with `--json-output` for the given tree and
+parameters, then summarize the response. The server returns pre-computed
+trend labels, anomaly flags, and contributor breakdowns — present them
+directly.
 
-## Analysis
-
-Analyze the trend data returned by the server. The response includes pre-computed trend labels, anomaly flags, and contributor breakdowns. Summarize these findings for the user.
-
-## Output format
-
-Return a structured summary:
+## Output
 
 - **Overall trend**: one-line pattern description
-- **Anomalous periods**: list with dates, magnitude, and primary driver
+- **Anomalous periods**: dates, magnitude, primary driver
 - **Seasonal pattern**: yes/no with description if yes
 - **Recommended drill-down**: which period + tree to investigate further
 
-Keep the output concise and factual. Do not speculate beyond what the data shows.
+Concise and factual. Do not speculate beyond what the data shows.

--- a/plugins/qluent/agents/trend-interpreter.md
+++ b/plugins/qluent/agents/trend-interpreter.md
@@ -1,6 +1,6 @@
 ---
 name: trend-interpreter
-description: Analyzes multi-period trend data from qluent to identify anomalies, seasonal patterns, and inflection points
+description: Multi-grain trend synthesis. Runs week+month trend in one pass and disambiguates one-off vs sustained movement before returning a single interpretation.
 tools: Bash(qluent *), Read
 model: sonnet
 color: blue
@@ -8,23 +8,68 @@ skills:
   - qluent-interpretation
 ---
 
-You are a trend analysis specialist. You receive trend data from the qluent
-CLI and produce a structured interpretation. Follow the
-`qluent-interpretation` skill for windows, provenance, and quantitative
-claims.
+You are a multi-grain trend specialist. Your job is to give the caller one
+answer to "is this movement a one-off or a sustained shift?" in a single call
+without making the orchestrator run two trend commands and reconcile them.
+Follow the `qluent-interpretation` skill for windows, provenance, and
+quantitative claims.
 
-## Task
+## Why this agent exists
 
-Run `qluent trees trend` with `--json-output` for the given tree and
-parameters, then summarize the response. The server returns pre-computed
-trend labels, anomaly flags, and contributor breakdowns — present them
-directly.
+A single-grain trend call is ambiguous: a weekly anomaly may be a sustained
+shift dampened by aggregation, or a one-off blip that disappears at the monthly
+grain. This agent overlays two grains and returns one disambiguated verdict.
+
+## Inputs
+
+- `tree_id` — required.
+- `period`, or `--current`/`--compare` windows. Reuse the windows from the
+  upstream investigation.
+- Optional `--as-of YYYY-MM-DD` reference date.
+
+## Workflow
+
+Anchor the trend overlay to the investigated window. If the caller supplied
+explicit `--current <start>:<end>` / `--compare <start>:<end>` windows, derive
+`<current_end>` from the end of the current window and pass it as `--as-of` to
+both grains. If the caller supplied only a natural-language `period`, pass that
+same period consistently when the CLI supports it; otherwise ask the caller for
+explicit windows before producing a verdict.
+
+Run both grain calls in parallel from a single shell turn when possible:
+
+```bash
+qluent trees trend <tree_id> --periods 8 --grain week --as-of <current_end> --json-output
+qluent trees trend <tree_id> --periods 6 --grain month --as-of <current_end> --json-output
+```
+
+If the CLI rejects either grain, report which grain ran and proceed with the
+partial overlay. If the trend result does not cover the investigated window,
+mark the verdict `inconclusive` instead of validating a different period.
+
+## Synthesis
+
+Cross-reference the two grains using only returned fields:
+
+1. **One-off signature**: a returned anomaly flag at week grain that does not
+   appear in the monthly trend's anomaly flags or returned period labels.
+2. **Sustained signature**: a returned trend label or anomaly flag visible at
+   both grains, or a monthly label that classifies the move as a regime/level
+   shift.
+3. **Pre-existing drift**: monthly grain shows a multi-period directional label
+   while weekly anomalies look like noise around it.
+4. **Aggregation artifact**: weekly grain shows volatility but monthly grain
+   shows no labeled movement and no anomaly.
 
 ## Output
 
-- **Overall trend**: one-line pattern description
-- **Anomalous periods**: dates, magnitude, primary driver
-- **Seasonal pattern**: yes/no with description if yes
-- **Recommended drill-down**: which period + tree to investigate further
+- **Disambiguation**: one of `one-off`, `sustained`, `pre-existing drift`,
+  `aggregation artifact`, `inconclusive`.
+- **Evidence**: which weekly and monthly fields support the verdict, with exact
+  period stamps.
+- **Anomalous periods**: periods flagged at either grain, with the grain noted.
+- **Seasonal pattern**: yes/no plus the returned seasonal label if present.
+- **Recommended drill**: the highest-value follow-up given the verdict.
 
-Concise and factual. Do not speculate beyond what the data shows.
+Concise and factual. Do not compute deltas, slopes, or anomaly thresholds
+yourself.

--- a/plugins/qluent/commands/compare.md
+++ b/plugins/qluent/commands/compare.md
@@ -1,7 +1,7 @@
 ---
 description: Compare two metric trees side-by-side to validate the mechanism behind a change
 argument-hint: "[tree1] [tree2] [--period 'last week' | --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+allowed-tools: Bash(qluent *), Read
 disable-model-invocation: true
 ---
 
@@ -10,6 +10,12 @@ disable-model-invocation: true
 Use as a follow-up after `/qluent:investigate`, not as a starting point.
 Resolve tree ids per the `qluent-interpretation` skill if `$ARGUMENTS` looks
 like a question rather than two tree ids.
+
+Before running the compare, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
 
 Natural-language periods:
 

--- a/plugins/qluent/commands/compare.md
+++ b/plugins/qluent/commands/compare.md
@@ -7,24 +7,23 @@ disable-model-invocation: true
 
 # Compare metric trees
 
-Use this as a follow-up after `/qluent:investigate`, not as a starting point.
+Use as a follow-up after `/qluent:investigate`, not as a starting point.
+Resolve tree ids per the `qluent-interpretation` skill if `$ARGUMENTS` looks
+like a question rather than two tree ids.
 
-If `$ARGUMENTS` looks like a question rather than two tree ids, run `qluent trees list --json-output`, pick the two most relevant trees from the list (match against tree label, child node labels, and declared dimensions), and re-run with those tree ids.
-
-Run a side-by-side comparison of two trees for the same period.
-
-For natural-language periods:
+Natural-language periods:
 
 ```bash
 qluent trees compare <tree1> <tree2> --period "$ARGUMENTS_PERIOD" --json-output
 ```
 
-For explicit date windows:
+Explicit windows:
 
 ```bash
 qluent trees compare <tree1> <tree2> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output
 ```
 
-## Interpret the results
+## Interpret
 
-The response includes pre-computed mechanism interpretations comparing the two trees. Present these to the user and suggest further drill-down if the mechanism is unclear.
+The response includes pre-computed mechanism interpretations. Present them
+and suggest further drill-down if the mechanism is unclear.

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -6,13 +6,14 @@ allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read
 
 # Deep dive across metric trees
 
-Use this command when the user wants one unified answer to "what changed across the
-business?" across revenue, growth, operations, conversion funnel, and any other
-configured trees.
+Use when the user wants one unified answer to "what changed across the
+business?" across revenue, growth, operations, conversion funnel, and any
+other configured trees.
 
-This command is opt-in and can be expensive: it runs investigations across all trees in
-parallel through the deterministic qluent CLI. Do not run it from SessionStart or as an
-implicit first step.
+Opt-in and potentially expensive: runs investigations across all trees in
+parallel through the deterministic qluent CLI. Do not run from SessionStart
+or as an implicit first step. Follow the `qluent-interpretation` skill for
+provenance, window handling, and quantitative-claim rules.
 
 ## Step 1: Check CLI availability and capability
 
@@ -151,17 +152,14 @@ Rank concrete follow-up commands across trees, not just within one tree.
 
 Rules for synthesis:
 
-- Ground every material quantitative claim in the returned JSON.
 - Prefer cross-tree convergence over per-tree trivia.
 - If revenue and conversion move in opposite directions, explain the tension.
-- If operations and conversion share a segment, call out the possible operational
-  mechanism but label it as an observed relationship unless the returned data supports
-  stronger causal language.
-- If a single tree dominates the story, say that and explain whether other trees confirm,
-  contradict, or are inconclusive.
-- Separate facts, interpretation, caveats, and recommendations.
-- Keep the narrative concise by default. If `--brief` is present, use shorter bullets
-  under each heading but still include all five headings.
+- If operations and conversion share a segment, call it out as an observed
+  relationship unless the data explicitly supports causal language.
+- If a single tree dominates the story, say so and state whether other trees
+  confirm, contradict, or are inconclusive.
+- Keep concise. If `--brief` is present, use shorter bullets but still include
+  all five headings.
 
 ## Next-best drill command format
 
@@ -183,10 +181,10 @@ order. Include why each drill is recommended in one sentence.
 
 ## Rules
 
-- Always check for qluent and the `trees deep-dive` subcommand before running analysis.
-- Always call `qluent trees deep-dive --json-output --period "<period>"`.
-- Always confirm before running unless `--yes` is present.
+- Check for qluent and the `trees deep-dive` subcommand before running.
+- Confirm before running unless `--yes` is present.
 - Never auto-fire from SessionStart.
-- Never manually fan out to individual tree investigations as a fallback.
+- Never manually fan out to individual `qluent trees investigate` calls as a
+  fallback — that loses the bundled cross-tree contract.
 - Per-tree errors and low-confidence findings must appear in Caveats.
-- Recommendations must be concrete slash commands for this plugin.
+- Recommendations must be concrete `/qluent:*` slash commands.

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -15,6 +15,14 @@ parallel through the deterministic qluent CLI. Do not run from SessionStart
 or as an implicit first step. Follow the `qluent-interpretation` skill for
 provenance, window handling, and quantitative-claim rules.
 
+## Step 0: Load the canonical interpretation protocol
+
+Before running the deep dive, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
+
 ## Step 1: Check CLI availability and capability
 
 Verify qluent is installed:

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -13,6 +13,14 @@ Follow the `qluent-interpretation` skill for tree resolution, window handling,
 provenance, Shapley/confidence interpretation, elasticity guardrails, and the
 unsupported-cut fallback. Do not invent metric math.
 
+## Step 0: Load the canonical interpretation protocol
+
+Before proceeding, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
+
 ## Step 1: Question vs tree id
 
 If `$ARGUMENTS` is empty, ends with `?`, contains spaces, or contains words
@@ -24,7 +32,7 @@ and resolve a tree (Step 2). If it is a single token (`revenue`, `roas`,
 
 Run `qluent trees list --json-output` and pick the best fit per the tree
 resolution rules in the `qluent-interpretation` skill. If no tree is a clear
-winner, ask with `AskUserQuestion`.
+winner, ask the user to choose from the top candidates.
 
 ## Step 3: Resolve windows
 

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -6,55 +6,40 @@ allowed-tools: Bash(qluent *), Read
 
 # Investigate KPI movement
 
-This is the primary entry point for all metric analysis. It bundles validation, trend, evaluation, and root cause analysis into a single call.
+Primary entry point for metric analysis. Bundles validation, trend,
+evaluation, and root cause analysis in one call.
 
-The qluent server is deterministic — it does NOT match natural-language questions to trees. YOU pick which tree to analyze when the user asks a question, by listing trees and matching against their metadata.
+Follow the `qluent-interpretation` skill for tree resolution, window handling,
+provenance, Shapley/confidence interpretation, elasticity guardrails, and the
+unsupported-cut fallback. Do not invent metric math.
 
-## Deterministic query contract
+## Step 1: Question vs tree id
 
-- Resolve tree context before analysis. Do not let natural language stand in for a tree id.
-- Run deterministic qluent JSON before making quantitative claims.
-- Use the returned root movement before explaining a change.
-- Use returned child decomposition, attribution, trend, comparison, lever, or segment fields before naming drivers or rankings.
-- Keep provenance for material findings: command/result type, tree id or label, node/segment, and exact current/comparison windows.
-- Separate facts, interpretation, caveats, and recommendations in the answer.
-- Do not invent, back-calculate, or estimate metric math that is not present in the returned qluent JSON.
+If `$ARGUMENTS` is empty, ends with `?`, contains spaces, or contains words
+like `why`, `what`, `how`, `drove`, `drop`, `spike`, treat it as a question
+and resolve a tree (Step 2). If it is a single token (`revenue`, `roas`,
+`order_volume`), use it as the tree id and skip to Step 3.
 
-## Step 1: Decide whether `$ARGUMENTS` is a tree id or a question
+## Step 2: Resolve a tree
 
-If `$ARGUMENTS` is empty, ends with `?`, contains spaces, or contains words like `why`, `what`, `how`, `drove`, `drop`, `spike`, treat it as a **question** and go to Step 2.
+Run `qluent trees list --json-output` and pick the best fit per the tree
+resolution rules in the `qluent-interpretation` skill. If no tree is a clear
+winner, ask with `AskUserQuestion`.
 
-If `$ARGUMENTS` is a single token (e.g. `revenue`, `order_volume`, `roas`), treat it as a **tree id** and skip to Step 3.
+## Step 3: Resolve windows
 
-## Step 2: List the available trees and pick the best fit
+Use `--current`/`--compare` verbatim if provided. Otherwise default to
+`--period "last week"` (or whatever phrase the user gave).
 
-Run:
+## Step 4: Run the bundled investigation
 
-```bash
-qluent trees list --json-output
-```
-
-Read each tree's `id`, `label`, `description`, declared `dimensions`, and the labels of its child nodes. Match the user's question against this metadata. Bias toward:
-
-- nouns in the question that match a tree label (e.g. "revenue" → revenue tree)
-- verbs/concepts that match a child node label (e.g. "spend efficiency" → a roas-style node)
-- dimensions named in the question (e.g. "by country" → tree that declares `country`)
-
-If no tree is a clear winner, ask the user with `AskUserQuestion`, listing the top 2–3 candidates with their labels and descriptions. Do NOT guess silently.
-
-## Step 3: Resolve the time windows
-
-If the user provided `--current` / `--compare`, use those verbatim. Otherwise default to `--period "last week"` (or whatever period phrase the user gave).
-
-## Step 4: Run the bundled investigation with an explicit tree id
-
-Always pipe qluent output through `tee` to save visualization data. This makes `/qluent:visualize` immediately available.
+Pipe through `tee` so `/qluent:visualize` is immediately available:
 
 ```bash
 qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
 ```
 
-For explicit date ranges:
+For explicit ranges:
 
 ```bash
 qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output 2>&1 | tee /tmp/qluent-viz-data.json
@@ -62,44 +47,28 @@ qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYY
 
 ## Step 5: Follow server recommendations
 
-The response includes an `agent` section with `status`, `top_findings`, `gaps`, and `recommended_next_steps`. The `levers` section contains embedded elasticity/lever data when available. Follow the server's recommendations to determine what to do next — run the suggested follow-up commands before inventing your own.
+The response includes an `agent` section with `status`, `top_findings`,
+`gaps`, and `recommended_next_steps`. The `levers` section embeds elasticity
+data when available. Run the recommended follow-ups before inventing your own.
 
-For complex cases, the server may recommend launching specialized agents (`trend-interpreter`, `rca-validator`, `segment-explorer`) in parallel.
+For complex cases, the server may recommend launching `trend-interpreter`,
+`rca-validator`, or `segment-explorer` in parallel.
 
-## Step 6: Summarize and suggest next steps
+## Step 6: Summarize and suggest
 
-If the user is asking about elasticity, leverage, scenario impact, or "what if":
+- Lead with the top findings from the server response.
+- State the exact current and comparison windows.
+- End with 2-3 concrete follow-up suggestions tailored to the data.
 
-- Read `levers` first before running anything else.
-- Reuse the exact current/comparison windows from the investigation bundle.
-- If you need a deeper scenario table, run:
+For elasticity/leverage/"what if" follow-ups: read `levers` first, reuse the
+exact windows, run `qluent trees levers <tree_id> --current <start>:<end>
+--compare <start>:<end> --json-output` only when the embedded block is
+insufficient. Apply the lever guardrails from the skill.
 
-```bash
-qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
-```
+For unsupported segment cuts: pivot to a compatible tree with the same
+windows; do not stop at the limitation.
 
-- Treat the result as a local linear estimate from the current operating point, not a forecast.
+For full-year ranges: if RCA times out, suggest quarterly breakdowns.
 
-If the user asks for a segment or breakdown that the current tree does not support:
-
-- Reuse the exact current/comparison windows from the investigation bundle.
-- Check the session tree context or run `qluent trees list --json-output` to find a compatible tree that exposes the missing dimension.
-- Re-run the investigation or RCA on that fallback tree with the same windows.
-- Synthesize both views instead of stopping: current tree for KPI-specific explanation, fallback tree for the requested segmentation.
-
-- Lead with the top findings from the server response
-- Report the exact current and comparison windows used
-- End with 2-3 concrete follow-up suggestions tailored to what the data shows
-
-## Rules
-
-- Always pass an explicit `<tree_id>` to `investigate`, chosen client-side via Step 2 (`qluent trees list --json-output`).
-- Always use `--json-output` when driving the workflow.
-- Require deterministic query output before every quantitative claim.
-- Cite result provenance for material findings.
-- Prefer the embedded `levers` block before rerunning commands for impact questions.
-- For full-year date ranges, if RCA times out, suggest quarterly breakdowns.
-- If the user asks a follow-up, check if the existing data answers it before re-running.
-- Never parse tool-result temp files or write ad-hoc scripts against prior bash output.
-- Do not rerun both JSON and non-JSON versions of the same qluent command unless JSON is genuinely insufficient.
-- If the requested cut is unsupported on the current tree, pivot to the closest compatible tree rather than handing control back.
+If the user asks a follow-up, check whether the existing data answers it
+before re-running.

--- a/plugins/qluent/commands/rca.md
+++ b/plugins/qluent/commands/rca.md
@@ -1,7 +1,7 @@
 ---
 description: Run standalone deterministic root cause analysis on a metric tree
 argument-hint: "[tree-name] [--period 'last week' | --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+allowed-tools: Bash(qluent *), Read
 disable-model-invocation: true
 ---
 
@@ -10,6 +10,12 @@ disable-model-invocation: true
 Use as a follow-up after `/qluent:investigate`, not as a starting point.
 Follow the `qluent-interpretation` skill for tree resolution, window reuse,
 provenance, and Shapley/confidence interpretation.
+
+Before running RCA, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
 
 ## Step 1: Resolve tree and window
 

--- a/plugins/qluent/commands/rca.md
+++ b/plugins/qluent/commands/rca.md
@@ -7,23 +7,26 @@ disable-model-invocation: true
 
 # Root cause analysis
 
-Use this as a follow-up after `/qluent:investigate`, not as a starting point.
+Use as a follow-up after `/qluent:investigate`, not as a starting point.
+Follow the `qluent-interpretation` skill for tree resolution, window reuse,
+provenance, and Shapley/confidence interpretation.
 
-If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id. If no tree is a clear fit, ask the user to choose from the top candidates. Quantitative RCA claims require returned `qluent rca analyze` JSON for the selected tree/window.
+## Step 1: Resolve tree and window
 
-## Step 1: Resolve tree and window deterministically
+Use the tree id and exact current/comparison windows from the prior
+`/qluent:investigate` result when available. If the user supplied a new
+period or explicit windows, use those verbatim. Quantitative RCA claims
+require returned `qluent rca analyze` JSON for the selected tree/window.
 
-Use the tree id and exact current/comparison windows from the prior `/qluent:investigate` result when available. If the user supplied a new period or explicit windows, use those verbatim. Do not infer quantitative movement without fresh qluent JSON for the chosen tree/window.
+## Step 2: Run RCA
 
-## Step 2: Run deterministic RCA
-
-For natural-language periods:
+Natural-language periods:
 
 ```bash
 qluent rca analyze <tree_id> --period "$ARGUMENTS_PERIOD" --json-output
 ```
 
-For explicit date windows:
+Explicit windows:
 
 ```bash
 qluent rca analyze <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output
@@ -31,36 +34,30 @@ qluent rca analyze <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-D
 
 ## Step 3: Rank material drivers
 
-Use only returned RCA fields to rank drivers. Prefer branches that are both material and supported by confidence/evidence fields. Do not exhaustively drill low-contribution branches unless the server response flags them as anomalous or strategically important.
-
-For each top driver, capture:
-
-- contribution share or attribution value
-- absolute delta when returned
-- confidence/evidence coverage
-- warnings, gaps, or data-quality flags
-- child nodes or dimensions available for a follow-up drill
+Use only returned RCA fields. Prefer branches that are both material and
+supported by confidence/evidence. Do not exhaustively drill low-contribution
+branches unless the response flags them as anomalous or strategically
+important. For each top driver, capture: contribution share / attribution,
+absolute delta when returned, confidence/evidence coverage, warnings or gaps,
+and child nodes/dimensions available for follow-up.
 
 ## Step 4: Choose next-best drills
 
-Turn the ranked drivers into 2-3 concrete next-best drills. Prefer:
+Turn the ranked drivers into 2-3 concrete next drills. Prefer:
 
-- segmenting the most material supported driver by available dimensions
+- segmenting the most material supported driver by an available dimension
 - checking mix vs behavior when the movement could be composition-driven
-- running `/qluent:compare` when mechanism validation across trees would reduce uncertainty
-- extending or splitting the time window when confidence is low or the movement is volatile
+- running `/qluent:compare` for cross-tree mechanism validation
+- extending or splitting the time window when confidence is low
 
-Weak, low-confidence, or immaterial results should produce validation/drill suggestions, not action recommendations.
+Weak / low-confidence / immaterial results produce drill suggestions, not
+action recommendations.
 
-## Step 5: Report the results
+## Step 5: Report
 
-The response includes pre-computed conclusions, attribution shares, confidence scores, and interpretation labels. Present these to the user:
-
-- Lead with the root cause and supporting evidence
-- List the top contributing nodes with their attribution shares
-- Note any gaps or warnings from the server response
-- State the exact current and comparison windows
-- Cite provenance for material findings: RCA result, tree id or label, node, and exact current/comparison windows
-- Separate returned facts from interpretation, caveats, and recommendations
-- Include caveats when materiality or confidence is insufficient
-- End with ranked next-best drills and why each one is next
+- Lead with the root cause and supporting evidence.
+- List top contributing nodes with attribution shares.
+- Note gaps or warnings from the response.
+- State the exact current and comparison windows.
+- Cite provenance per the skill.
+- End with ranked next-best drills and one-sentence rationale for each.

--- a/plugins/qluent/commands/trend.md
+++ b/plugins/qluent/commands/trend.md
@@ -7,20 +7,20 @@ disable-model-invocation: true
 
 # Trend analysis
 
-Use this as a follow-up after `/qluent:investigate`, not as a starting point.
+Use as a follow-up after `/qluent:investigate`, not as a starting point.
 
-If `$ARGUMENTS` looks like a question rather than a tree id, run `qluent trees list --json-output`, pick the best-fitting tree from the list (match against tree label, child node labels, and declared dimensions), and re-run with that tree id.
-
-Parse the arguments from `$ARGUMENTS` and run:
+Resolve the tree id per the `qluent-interpretation` skill if `$ARGUMENTS`
+looks like a question. Then run:
 
 ```bash
 qluent trees trend <tree_id> --periods <N> --grain <grain> --json-output
 ```
 
-Defaults if not provided: periods=4, grain=week. Use grain=month for longer-range analysis.
+Defaults: `periods=4`, `grain=week`. Use `grain=month` for longer ranges. Pin
+the reference date with `--as-of YYYY-MM-DD`.
 
-To pin the reference date, add `--as-of YYYY-MM-DD`.
+## Interpret
 
-## Interpret the results
-
-The response includes pre-computed trend labels and anomaly flags for each period. Present these to the user and suggest drilling into anomalous periods with `/qluent:investigate` or `/qluent:rca`.
+The response includes pre-computed trend labels and anomaly flags. Present
+them and suggest drilling into anomalous periods with `/qluent:investigate`
+or `/qluent:rca`.

--- a/plugins/qluent/commands/trend.md
+++ b/plugins/qluent/commands/trend.md
@@ -1,13 +1,21 @@
 ---
 description: Run multi-period trend analysis for a metric tree
 argument-hint: "[tree-name] [--periods 4] [--grain week|month] [--as-of YYYY-MM-DD]"
-allowed-tools: Bash(qluent *)
+allowed-tools: Bash(qluent *), Read
 disable-model-invocation: true
 ---
 
 # Trend analysis
 
 Use as a follow-up after `/qluent:investigate`, not as a starting point.
+
+Before running trend analysis, `Read` the canonical interpretation Module so
+the deterministic-query protocol, trend label semantics, and anomaly-flag
+handling are in context:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
 
 Resolve the tree id per the `qluent-interpretation` skill if `$ARGUMENTS`
 looks like a question. Then run:

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -13,6 +13,14 @@ only on `--simple`/`--html`, an explicit local/browser request, or when the
 UI contract cannot be consumed. Follow the `qluent-interpretation` skill for
 provenance and evidence labels.
 
+## Step 0: Load the canonical interpretation protocol
+
+Before shaping a report, `Read` the canonical interpretation Module:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
+```
+
 ## Step 1: Locate and validate the data
 
 By default, read from `/tmp/qluent-viz-data.json`. If the user provides `--file <path>`, use

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -6,11 +6,12 @@ allowed-tools: Bash(*), Read, Write, Glob
 
 # Visualize qluent output
 
-Shapes the most recent qluent analysis into an outcome-shaped `RcaReportSpec` for the
-Qluent UI. When deterministic RCA or elasticity output is available, the report spec is
-the required primary artifact. Use local HTML only when the user explicitly requests a
-local/browser demo, passes `--simple` or `--html`, or the UI report contract cannot be
-consumed.
+Shapes the most recent qluent analysis into an outcome-shaped `RcaReportSpec`
+for the Qluent UI. When deterministic RCA or elasticity output is available
+the report spec is the required primary artifact. Local HTML is a fallback
+only on `--simple`/`--html`, an explicit local/browser request, or when the
+UI contract cannot be consumed. Follow the `qluent-interpretation` skill for
+provenance and evidence labels.
 
 ## Step 1: Locate and validate the data
 
@@ -117,18 +118,15 @@ backed by actual qluent fields:
 
 ### Provenance and evidence labels
 
-Every material section must preserve deterministic provenance:
-
-- Include the qluent command/result type, tree id or label, node id/label, segment
-  dimension/value when present, exact current/comparison windows, materiality, and
-  confidence/evidence coverage.
-- Carry caveats from returned `gaps`, low confidence, sparse samples, missing dimensions,
-  unsupported cuts, guardrail warnings, stale windows, or unequal current/comparison
-  period lengths into top-level `caveats[]`.
-- Carry result references and data lineage into `sources[]`; do not cite unstated data.
-- Use CLI/UI evidence labels exactly when present: `observed_correlation`,
-  `historical_elasticity`, `model_estimate`, and `experiment_backed`.
-- Separate returned facts from interpretation, caveats, and recommendations.
+Every material section preserves provenance per the `qluent-interpretation`
+skill: command/result type, tree id/label, node id/label, segment
+dimension/value, exact current/comparison windows, materiality, and
+confidence/evidence coverage. Carry returned caveats (gaps, low confidence,
+sparse samples, missing dimensions, unsupported cuts, guardrail warnings,
+stale or unequal-length windows) into top-level `caveats[]`. Carry result
+references and data lineage into `sources[]`. Use returned evidence labels
+exactly when present: `observed_correlation`, `historical_elasticity`,
+`model_estimate`, `experiment_backed`.
 
 ## Step 4: HTML fallback for local demos
 
@@ -155,16 +153,14 @@ xdg-open "$out"
 
 ## Rules
 
-- Always read the data file first to verify freshness before rendering
-- Prefer an outcome-shaped `RcaReportSpec` with `outcomeShape` and ordered `sections[]`
-  whenever deterministic RCA or elasticity output is available
-- Do not hand-roll report HTML when the UI report contract can be used
-- Preserve deterministic provenance, caveats, date windows, materiality, and evidence labels
-- Use unique fallback HTML output paths; do not silently reuse stale dashboards
-- Preserve period comparability caveats in both `RcaReportSpec` output and HTML fallback
-- Use the `dashboard-design` skill for explicit HTML fallback design decisions — do not invent new styles
-- Section titles must be insight statements, not generic labels
-- Only include sections backed by actual data — never generate placeholder charts
-- If values cannot be mapped from the qluent JSON or explicit user-provided input, omit
-  the section or state the missing deterministic field/query
-- Prefer fewer, well-designed sections over many sparse ones
+- Read the data file first to verify freshness before rendering.
+- Prefer an outcome-shaped `RcaReportSpec` whenever deterministic RCA or
+  elasticity output is available.
+- Do not hand-roll report HTML when the UI contract can be used.
+- Use unique fallback HTML output paths; do not silently reuse stale dashboards.
+- Use the `dashboard-design` skill for HTML fallback styling — do not invent
+  new styles.
+- Section titles are insight statements, not generic labels.
+- Only include sections backed by actual data; omit the section or state the
+  missing deterministic field if values cannot be mapped from the JSON.
+- Prefer fewer, well-designed sections over many sparse ones.

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -1,66 +1,153 @@
 ---
 name: qluent-interpretation
-description: Internal reference for interpreting qluent CLI output — Shapley attribution, trend labels, RCA confidence scores
+description: Canonical protocol for interpreting qluent CLI output — tree resolution, windows, provenance, Shapley, elasticity guardrails, and segment-cut fallback. Referenced by every qluent command and agent; do not duplicate these rules elsewhere.
 user-invocable: false
 ---
 
-# Interpreting qluent results
+# Qluent interpretation protocol
 
-The qluent server returns pre-interpreted analysis results. Present the server-provided labels, scores, and interpretations directly to the user.
+The qluent server is deterministic. It returns pre-interpreted analysis (root
+movement, Shapley attribution, trend labels, mechanism interpretations,
+confidence scores, elasticity tables). Your job is to drive it correctly and
+present what it returns — not to recompute, infer, or paraphrase the math.
 
-Key principles:
-- Quantitative claims must come from deterministic qluent JSON returned in the current workflow. Do not invent metric values, deltas, percentages, attribution shares, or segment rankings.
-- Every material finding should cite its provenance in plain language: command/result type, tree id or label, node/segment, and current/comparison windows.
-- Separate facts from interpretation, caveats, and recommendations. Facts are returned values; interpretation is the server-provided label or your synthesis from returned evidence.
-- Confidence scores are evidence-coverage heuristics, not probabilities. Never describe them as likelihoods.
-- Attribution values are computed server-side using Shapley values from cooperative game theory.
-- Trend labels, anomaly flags, and mechanism interpretations are included in the server response.
-- When a `levers` block is available, lever impacts are local linear estimates from the current operating point, not forecasts.
+This skill is the single source of truth for protocol. Commands and agents
+should reference it by name rather than restating the rules.
 
-## Deterministic query protocol
+## Tree resolution
 
-Before making quantitative claims:
+The server does not match natural-language questions to trees. Pick a tree id
+client-side before any quantitative call.
 
-1. Resolve tree context from session tree metadata or `qluent trees list --json-output`.
-2. Run the deterministic qluent command that returns the needed evidence, always with `--json-output`.
-3. Use root movement from `qluent trees investigate`, `qluent rca analyze`, or another returned JSON field before explaining a change.
-4. Use child decomposition, attribution, trend, comparison, lever, or segment fields only after the command has returned them.
-5. Preserve result provenance in the answer: tree, node/segment, command type, and exact windows.
+1. If the user named a tree (`revenue`, `order_volume`, `roas`), use it directly.
+2. Otherwise run `qluent trees list --json-output` and match the question
+   against each tree's `id`, `label`, `description`, declared `dimensions`, and
+   child node labels. Bias toward:
+   - nouns that match a tree label (e.g. "revenue" → revenue tree)
+   - concepts that match a child node label (e.g. "spend efficiency" → roas)
+   - dimensions named in the question (e.g. "by country" → tree declaring `country`)
+3. If no tree is a clear winner, ask the user with `AskUserQuestion`, listing
+   the top 2–3 candidates with labels and descriptions. Do not guess silently.
 
-Never back-calculate missing values, interpolate absent segment rankings, or combine numbers from different windows as if they were one result. If the required deterministic output is missing, say what query is needed next.
+Always pass an explicit `<tree_id>` to every qluent subcommand. Always use
+`--json-output`.
+
+## Windows
+
+Reuse the exact `current_window` and `comparison_window` from the prior
+investigation when answering follow-ups. Do not infer a new period unless the
+user changed it.
+
+- Natural-language periods: `--period "last week"`.
+- Explicit windows: `--current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD`.
+- If the user gave neither, default to `--period "last week"` for `investigate`
+  and ask via `AskUserQuestion` for `deep-dive`.
+
+When current and comparison windows have different day counts, surface that as
+a caveat near the headline.
+
+## Quantitative claims
+
+Every metric value, delta, decomposition, segment ranking, elasticity estimate,
+and ranked recommendation must be grounded in deterministic qluent JSON
+returned during the current workflow.
+
+- Query root movement before explaining what changed.
+- Query child decomposition before naming drivers.
+- Drill into material drivers only after returned attribution or
+  `agent.recommended_next_steps` identifies them.
+- Do not invent, back-calculate, interpolate, or combine metric math outside
+  the returned qluent fields.
+- Never parse tool-result temp files or write ad-hoc scripts against prior
+  bash output.
+- Do not rerun both JSON and non-JSON versions of the same command unless JSON
+  is genuinely insufficient.
+
+For every material finding, cite provenance in plain language: result type,
+tree id or label, node/segment, exact current/comparison windows. Separate
+returned facts from interpretation, caveats, and recommendations.
+
+If a required field is missing, run the deterministic follow-up query or state
+the missing query — do not fill the gap from prose.
+
+## Confidence and Shapley
+
+- Confidence scores are evidence-coverage heuristics. Never describe them as
+  probabilities or likelihoods.
+- Attribution values are computed server-side using Shapley values from
+  cooperative game theory. Use the returned numbers; do not redistribute them.
+- Trend labels, anomaly flags, and mechanism interpretations are returned by
+  the server. Present them; do not relabel.
 
 ## Elasticity and lever guardrails
 
-Elasticity output is directional decision support, not causal proof. Treat it as a measured association from the returned sample window unless the server response explicitly includes causal validation.
+Elasticity output is directional decision support, not causal proof. Treat it
+as a measured association from the returned sample window unless the response
+explicitly includes causal validation.
 
 When interpreting `levers`, `elasticity`, scenario, or impact fields:
 
-- Label the evidence type: elasticity estimate, Shapley attribution, trend corroboration, segment concentration, or server-provided causal validation.
-- State the exact sample windows used and the dimensions or cuts included in the returned result.
-- Report the server-provided confidence, materiality, data-quality warnings, and guardrail metrics before recommending any lever change.
-- Distinguish correlation and sensitivity from causality. Do not write that a lever "caused" root KPI movement unless a returned field explicitly supports causal language.
-- Treat low confidence, immaterial effects, sparse windows, volatile segments, or guardrail warnings as reasons to suggest the next drill or test, not an action plan.
-- For scenario rows such as +1%, +5%, or +10%, say they are local linear estimates from the current operating point and may not hold outside the observed range.
+- Label the evidence type using the returned label when present:
+  `observed_correlation`, `historical_elasticity`, `model_estimate`,
+  `experiment_backed`.
+- State the exact sample windows and dimensions/cuts in the returned result.
+- Report server-provided confidence, materiality, data-quality warnings, and
+  guardrail metrics before recommending any lever change.
+- Distinguish correlation and sensitivity from causality. Do not write that a
+  lever "caused" a movement unless a returned field supports causal language.
+- Treat low confidence, immaterial effects, sparse windows, volatile segments,
+  or guardrail warnings as reasons to suggest the next drill or test, not an
+  action plan.
+- Scenario rows (+1%, +5%, +10%) are local linear estimates from the current
+  operating point and may not hold outside the observed range.
 
-Recommendations require all of these conditions:
+Recommend a lever change only when all of these hold in the returned result:
 
-- The lever effect is material in the returned result, not just directionally interesting.
-- Confidence or evidence coverage is sufficient according to the server response.
-- Guardrail metrics do not show an offsetting risk or unresolved data-quality warning.
-- The recommendation is scoped to the returned sample window and segment/dimension context.
+1. The lever effect is material, not merely directional.
+2. Confidence/evidence coverage is sufficient.
+3. Guardrail metrics show no offsetting risk and no unresolved data-quality
+   warning.
+4. The recommendation is scoped to the returned sample window and segment.
 
-If those conditions are not met, recommend the next best drill instead. Examples include extending the window, validating the same lever across another segment, running `/qluent:compare`, or asking for an experiment/instrumentation check.
+Otherwise recommend the next drill: extend the window, validate across another
+segment, run `/qluent:compare`, or request an experiment/instrumentation check.
 
-Acceptable phrasing:
+Acceptable: *"The returned elasticity table shows a directional association in
+2026-04-13:2026-04-19 vs 2026-04-06:2026-04-12; conversion rate has the largest
+local sensitivity, with sufficient evidence coverage and no guardrail warning.
+Treat the +5% row as a local estimate, not a forecast."*
 
-- "The returned elasticity table shows a directional association: in 2026-04-13:2026-04-19 vs 2026-04-06:2026-04-12, conversion rate has the largest local sensitivity, with sufficient evidence coverage and no guardrail warning. Treat the +5% row as a local estimate, not a forecast."
-- "This is weak evidence for action. The lever is directionally positive, but the returned confidence is low and the segment sample is sparse, so the next step is to drill by channel before changing spend."
-- "The RCA attributes most of the movement to average order value, while the elasticity estimate says conversion rate is the larger local lever. That is a mechanism hypothesis, not proof that changing conversion caused the prior movement."
+Unacceptable: *"Increase conversion by 5% and revenue will rise by the
+scenario amount."* — overstates causality and ignores guardrails.
 
-Unacceptable phrasing:
+For follow-ups about elasticity, leverage, or "what if": read the embedded
+`investigate.levers` block first. Run `qluent trees levers <tree_id> --current
+<start>:<end> --compare <start>:<end> --json-output` only when the embedded
+block is insufficient.
 
-- "Increase conversion by 5% and revenue will rise by the scenario amount."
-- "The elasticity proves conversion caused the revenue drop."
-- "This lever is the best action" when confidence, materiality, guardrails, or sample windows are missing.
+## Unsupported segment cuts
 
-Refer to the server response fields for all interpretation details.
+If the user asks for a dimension the current tree does not expose:
+
+1. Reuse the exact current/comparison windows from the prior result.
+2. Check the session tree catalog (or run `qluent trees list --json-output`)
+   for a compatible tree that declares the missing dimension.
+3. Re-run the investigation or RCA on the fallback tree with the same windows.
+4. Synthesize both views: original tree for KPI-specific reasoning, fallback
+   tree for the requested segmentation. State which tree provided which view.
+
+Never stop at the limitation. The PostToolUse hook surfaces compatible
+fallback trees automatically — follow its suggestions.
+
+## Visualization
+
+When deterministic RCA or elasticity output is available, the primary artifact
+is a `RcaReportSpec` produced by `/qluent:visualize`. Do not hand-roll HTML,
+CSS, or Chart.js for normal analysis output. Local HTML is a fallback only
+when the user explicitly requests `--simple`/`--html`/a browser demo, or the
+UI report contract is unavailable.
+
+See `/qluent:visualize` for the section mapping (`root_movement`,
+`driver_decomposition`, `material_segment_scan`, `mix_shift`,
+`elasticity_summary`, `next_drills`) and the `dashboard-design` skill for HTML
+fallback styling.

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qluent-interpretation
-description: Canonical protocol for interpreting qluent CLI output — tree resolution, windows, provenance, Shapley, elasticity guardrails, and segment-cut fallback. Referenced by every qluent command and agent; do not duplicate these rules elsewhere.
-user-invocable: false
+description: Canonical protocol for interpreting qluent CLI output — tree resolution, windows, provenance, Shapley, elasticity guardrails, and segment-cut fallback. Loaded by qluent commands and agents; user-invocable for protocol inspection.
+user-invocable: true
 ---
 
 # Qluent interpretation protocol
@@ -26,8 +26,9 @@ client-side before any quantitative call.
    - nouns that match a tree label (e.g. "revenue" → revenue tree)
    - concepts that match a child node label (e.g. "spend efficiency" → roas)
    - dimensions named in the question (e.g. "by country" → tree declaring `country`)
-3. If no tree is a clear winner, ask the user with `AskUserQuestion`, listing
-   the top 2–3 candidates with labels and descriptions. Do not guess silently.
+3. If no tree is a clear winner, ask the user to choose from the top 2–3
+   candidates with labels and descriptions. Use `AskUserQuestion` only when
+   the caller has that tool; otherwise ask in plain text. Do not guess silently.
 
 Always pass an explicit `<tree_id>` to every qluent subcommand. Always use
 `--json-output`.
@@ -41,7 +42,8 @@ user changed it.
 - Natural-language periods: `--period "last week"`.
 - Explicit windows: `--current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD`.
 - If the user gave neither, default to `--period "last week"` for `investigate`
-  and ask via `AskUserQuestion` for `deep-dive`.
+  and ask for a period before `deep-dive`. Use `AskUserQuestion` only when the
+  caller has that tool; otherwise ask in plain text.
 
 When current and comparison windows have different day counts, surface that as
 a caveat near the headline.


### PR DESCRIPTION
Apply the "improve codebase architecture" skill: identify shallow modules re-stating the same protocol and deepen the canonical Module so callers can reference it through a small interface.

Before: tree-resolution, window-reuse, provenance, Shapley/confidence, and unsupported-cut fallback rules were duplicated across CLAUDE.md, six command files, and four agents. A change to the protocol meant editing six places.

After: qluent-interpretation/SKILL.md is the single source of truth for the deterministic-query protocol. Commands and agents reference it by name; the three specialized agents now declare it via `skills:` frontmatter. CLAUDE.md and the command bodies carry only command-specific guidance.

Behavior unchanged. Net -41 lines, but the locality win is bigger than the diff: protocol changes now happen in one file instead of six.

Bumped to 0.3.0.