### PR TITLE
release: bump plugin to 0.3.1 and expose prompt version marker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,15 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.3.0"
+    "version": "0.3.1",
+    "promptVersion": "2026-04-28-rspec-strict"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.3.0",
+      "version": "0.3.1",
+      "promptVersion": "2026-04-28-rspec-strict",
       "author": {
         "name": "Qluent"
       },

--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ Requires a qluent CLI release that includes `qluent trees deep-dive` from
 `qluent-cli#40`. Older CLIs are detected and the command exits with an upgrade warning
 instead of falling back to separate tree investigations.
 
+## Verifying the installed prompt bundle
+
+Every release tags the prompt bundle with a `promptVersion` marker so dogfood
+transcripts can prove which version Claude actually loaded. Current marker:
+
+```
+plugin 0.3.1 | prompt 2026-04-28-rspec-strict
+```
+
+The session-start hook prints this line on every Claude Code launch, and
+`/qluent:setup` echoes it in its summary. To verify by hand:
+
+```bash
+claude plugin list
+# qluent@qluent-metric-trees should show Version: 0.3.1
+
+grep -r "2026-04-28-rspec-strict" ~/.claude/plugins/installed
+```
+
+If the installed bundle still reports `0.3.0` or the marker is missing, the
+marketplace cache is stale. Refresh with:
+
+```
+/plugin marketplace update qluent/qluent-plugin-cc
+/reload-plugins
+```
+
 ## License
 
 MIT

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "qluent",
-  "version": "0.3.0",
+  "version": "0.3.1",
+  "promptVersion": "2026-04-28-rspec-strict",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -1,5 +1,7 @@
 # Qluent Metric Trees
 
+Prompt version: 2026-04-28-rspec-strict (plugin 0.3.1)
+
 Deterministic KPI analysis from the command line. This plugin provides slash
 commands for investigating business metric movements using metric trees.
 

--- a/plugins/qluent/commands/setup.md
+++ b/plugins/qluent/commands/setup.md
@@ -77,7 +77,11 @@ The goal is to get the user into analysis immediately after setup, not leave the
 ## Output
 
 Present a summary:
+- Plugin: qluent 0.3.1 (prompt 2026-04-28-rspec-strict)
 - Installation: installed / not installed
 - Authentication: configured / not configured
 - Metric trees: N available (with descriptions and what each can answer)
 - Suggested first question based on available trees
+
+Always echo the plugin version line verbatim so dogfood transcripts capture
+which prompt bundle Claude loaded.

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -11,6 +11,8 @@ fi
 
 [ -n "$python_bin" ] || exit 0
 
+echo "[Qluent] plugin 0.3.1 | prompt 2026-04-28-rspec-strict"
+
 # Check if qluent is available
 if ! command -v qluent &>/dev/null; then
   cat <<'EOF'


### PR DESCRIPTION
Adds a visible "plugin 0.3.1 | prompt 2026-04-28-rspec-strict" marker so dogfood transcripts can prove which prompt bundle Claude actually loaded when investigating stale-marketplace bugs.

- bump plugin/marketplace version 0.3.0 -> 0.3.1
- add promptVersion field to plugin.json and marketplace.json
- print marker line in session-start hook on every launch
- echo marker in /qluent:setup summary
- document the marker and the cache-refresh workflow in README
- add marker line at the top of plugins/qluent/CLAUDE.md

Fixes #38