### PR TITLE
Revert "release: bump plugin to 0.3.1 and expose prompt version marker"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,13 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.3.1",
-    "promptVersion": "2026-04-28-rspec-strict"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.3.1",
-      "promptVersion": "2026-04-28-rspec-strict",
+      "version": "0.3.0",
       "author": {
         "name": "Qluent"
       },

--- a/README.md
+++ b/README.md
@@ -84,33 +84,6 @@ Requires a qluent CLI release that includes `qluent trees deep-dive` from
 `qluent-cli#40`. Older CLIs are detected and the command exits with an upgrade warning
 instead of falling back to separate tree investigations.
 
-## Verifying the installed prompt bundle
-
-Every release tags the prompt bundle with a `promptVersion` marker so dogfood
-transcripts can prove which version Claude actually loaded. Current marker:
-
-```
-plugin 0.3.1 | prompt 2026-04-28-rspec-strict
-```
-
-The session-start hook prints this line on every Claude Code launch, and
-`/qluent:setup` echoes it in its summary. To verify by hand:
-
-```bash
-claude plugin list
-# qluent@qluent-metric-trees should show Version: 0.3.1
-
-grep -r "2026-04-28-rspec-strict" ~/.claude/plugins/installed
-```
-
-If the installed bundle still reports `0.3.0` or the marker is missing, the
-marketplace cache is stale. Refresh with:
-
-```
-/plugin marketplace update qluent/qluent-plugin-cc
-/reload-plugins
-```
-
 ## License
 
 MIT

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "qluent",
-  "version": "0.3.1",
-  "promptVersion": "2026-04-28-rspec-strict",
+  "version": "0.3.0",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -1,7 +1,5 @@
 # Qluent Metric Trees
 
-Prompt version: 2026-04-28-rspec-strict (plugin 0.3.1)
-
 Deterministic KPI analysis from the command line. This plugin provides slash
 commands for investigating business metric movements using metric trees.
 

--- a/plugins/qluent/commands/setup.md
+++ b/plugins/qluent/commands/setup.md
@@ -77,11 +77,7 @@ The goal is to get the user into analysis immediately after setup, not leave the
 ## Output
 
 Present a summary:
-- Plugin: qluent 0.3.1 (prompt 2026-04-28-rspec-strict)
 - Installation: installed / not installed
 - Authentication: configured / not configured
 - Metric trees: N available (with descriptions and what each can answer)
 - Suggested first question based on available trees
-
-Always echo the plugin version line verbatim so dogfood transcripts capture
-which prompt bundle Claude loaded.

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -11,8 +11,6 @@ fi
 
 [ -n "$python_bin" ] || exit 0
 
-echo "[Qluent] plugin 0.3.1 | prompt 2026-04-28-rspec-strict"
-
 # Check if qluent is available
 if ! command -v qluent &>/dev/null; then
   cat <<'EOF'


### PR DESCRIPTION
## Summary

Reverts the version bump and prompt-version-marker changes applied for issue #38.

This branches from `claude/bump-plugin-version-OAcVs` (which contains the fix commit `94891b2`) and adds a single revert commit on top, restoring `plugin.json` and `marketplace.json` to `0.3.0` and removing the `2026-04-28-rspec-strict` marker from `CLAUDE.md`, `setup.md`, the session-start hook, and the README verification section.

## Why

Per request: apply the fix for #38, then revert it via a PR so the change can be reviewed in isolation before re-landing.

## Test plan

- [ ] Confirm `plugin.json` version returns to `0.3.0` and `promptVersion` field is removed
- [ ] Confirm `marketplace.json` version returns to `0.3.0` in both `metadata` and `plugins[0]`
- [ ] Confirm session-start hook no longer prints the marker line
- [ ] Confirm `/qluent:setup` summary no longer references `0.3.1` / `2026-04-28-rspec-strict`
- [ ] Confirm README "Verifying the installed prompt bundle" section is removed

Refs #38

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWrhCAo5NfQfJjG5SYGPK8)_