### PR TITLE
[codex] Fix fallback renderer JSON binding

### DIFF
--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -40,7 +40,7 @@ it directly. Otherwise list trees and pick the best fit; ask the user with
 the top 2–3 candidates if no clear winner.
 
 ```bash
-qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
+qluent trees investigate <tree_id> --period "<period>" --json-output | tee /tmp/qluent-viz-data.json
 ```
 
 Always pipe through `tee` to auto-save visualization data.

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -44,13 +44,13 @@ Use `--current`/`--compare` verbatim if provided. Otherwise default to
 Pipe through `tee` so `/qluent:visualize` is immediately available:
 
 ```bash
-qluent trees investigate <tree_id> --period "<period>" --json-output 2>&1 | tee /tmp/qluent-viz-data.json
+qluent trees investigate <tree_id> --period "<period>" --json-output | tee /tmp/qluent-viz-data.json
 ```
 
 For explicit ranges:
 
 ```bash
-qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output 2>&1 | tee /tmp/qluent-viz-data.json
+qluent trees investigate <tree_id> --current YYYY-MM-DD:YYYY-MM-DD --compare YYYY-MM-DD:YYYY-MM-DD --json-output | tee /tmp/qluent-viz-data.json
 ```
 
 ## Step 5: Follow server recommendations

--- a/plugins/qluent/scripts/render-charts.sh
+++ b/plugins/qluent/scripts/render-charts.sh
@@ -19,6 +19,19 @@ if [ ! -f "$TEMPLATE" ]; then
   exit 1
 fi
 
+perl -MJSON::PP -0777 -e '
+  my ($input) = @ARGV;
+  open my $json_fh, "<", $input or die "Error: Cannot read input file: $input\n";
+  my $json = <$json_fh>;
+  close $json_fh;
+  eval { JSON::PP->new->decode($json); 1 } or do {
+    my $err = $@ || "unknown parse error";
+    print STDERR "Error: Input is not valid JSON: $input\n";
+    print STDERR "  $err";
+    exit 1;
+  };
+' "$INPUT"
+
 perl -0777 -e '
   use strict;
   use warnings;

--- a/plugins/qluent/templates/render-charts.html
+++ b/plugins/qluent/templates/render-charts.html
@@ -360,6 +360,35 @@ function pickNormalizedDelta(data) {
   ];
   return candidates.find(v => v != null);
 }
+function getEvaluation(data) {
+  return data?.evaluation || {};
+}
+function getRootNode(data) {
+  const ev = getEvaluation(data);
+  return ev.root || ev.root_metric || (ev.nodes || []).find(n => n.parent_id === null) || null;
+}
+function getRootContributors(data) {
+  const root = getRootNode(data);
+  if (root?.contributions?.length) return root.contributions;
+  const evContribs = data?.evaluation?.top_contributors || [];
+  if (evContribs.length) return evContribs;
+  return (data?.root_cause?.conclusion?.takeaways || [])
+    .filter(t => t.kind === 'driver' || t.kind === 'mechanism')
+    .map(t => ({
+      node_id: t.node_id,
+      label: t.title || t.node_id,
+      delta_value: t.delta_value ?? t.effect_value,
+      delta_share: t.share_of_change,
+      summary: t.summary
+    }))
+    .filter(t => t.delta_value != null || t.delta_share != null);
+}
+function getConfidenceConclusion(data) {
+  return data?.root_cause?.conclusion || data?.root_cause || {};
+}
+function getTakeaways(data) {
+  return data?.root_cause?.conclusion?.takeaways || [];
+}
 </script>
 
 <div class="main">
@@ -385,16 +414,17 @@ function pickNormalizedDelta(data) {
   // Update topbar
   document.querySelector('.topbar .page-title').textContent = label + ' Analysis';
 
-  const ev = qdata.evaluation;
-  if (ev && ev.current_value != null) {
+  const ev = getEvaluation(qdata);
+  const rootNode = getRootNode(qdata);
+  if (rootNode && rootNode.current_value != null) {
     const row = document.getElementById('kpi-row');
     row.insertAdjacentHTML('beforeend', `
       <div class="kpi-card">
-        <div class="kpi-value">${fmtCurrency(ev.current_value)}</div>
-        <div class="kpi-delta ${deltaClass(ev.delta_ratio)}">${fmtPct(ev.delta_ratio)} (${fmtCurrency(ev.delta_value)})</div>
-        <div class="kpi-label">${esc(ev.tree_label || 'Total')}</div>
+        <div class="kpi-value">${fmtCurrency(rootNode.current_value)}</div>
+        <div class="kpi-delta ${deltaClass(rootNode.delta_ratio)}">${fmtPct(rootNode.delta_ratio)} (${fmtCurrency(rootNode.delta_value)})</div>
+        <div class="kpi-label">${esc(rootNode.label || ev.tree_label || 'Total')}</div>
       </div>`);
-    (ev.top_contributors || []).forEach(c => {
+    getRootContributors(qdata).forEach(c => {
       row.insertAdjacentHTML('beforeend', `
         <div class="kpi-card">
           <div class="kpi-value" style="font-size:1.15rem">${fmtCurrency(c.delta_value)}</div>
@@ -419,10 +449,9 @@ function pickNormalizedDelta(data) {
 
   // Pre-compute shared eval tree data for chart sections
   if (ev && ev.nodes) {
-    const root = ev.nodes.find(n => n.parent_id === null);
-    if (root) {
-      window._evalRoot = root;
-      window._evalChildren = ev.nodes.filter(n => n.parent_id === root.id)
+    if (rootNode) {
+      window._evalRoot = rootNode;
+      window._evalChildren = ev.nodes.filter(n => n.parent_id === rootNode.id)
         .sort((a, b) => Math.abs(b.delta_value) - Math.abs(a.delta_value));
     }
   }
@@ -437,8 +466,9 @@ function pickNormalizedDelta(data) {
 </div>
 <script>
 (function() {
-  const agent = qdata.agent;
-  if (!agent) { document.getElementById('agent-section').classList.add('hidden'); return; }
+  const agent = qdata.agent || {};
+  const takeaways = getTakeaways(qdata);
+  if (!agent.top_findings?.length && !takeaways.length) { document.getElementById('agent-section').classList.add('hidden'); return; }
 
   const status = agent.status || 'unknown';
   const statusClass = 'status-' + status;
@@ -453,7 +483,7 @@ function pickNormalizedDelta(data) {
   }
 
   const findingsEl = document.getElementById('agent-findings');
-  const findings = agent.top_findings || [];
+  const findings = agent.top_findings || takeaways.map(t => t.summary || t.title).filter(Boolean);
   if (findings.length) {
     findings.forEach(f => {
       const div = document.createElement('div');
@@ -740,12 +770,12 @@ function pickNormalizedDelta(data) {
 </div>
 <script>
 (function() {
-  const contributors = qdata.root_cause?.top_contributors || [];
+  const contributors = getRootContributors(qdata);
   if (!contributors.length) { document.getElementById('rca-section').classList.add('hidden'); return; }
 
   const sorted = [...contributors].sort((a, b) => Math.abs(b.shapley_share || b.percentage_share || 0) - Math.abs(a.shapley_share || a.percentage_share || 0));
-  const labels = sorted.map(c => c.node || c.node_id || 'Unknown');
-  const shares = sorted.map(c => ((c.shapley_share || c.percentage_share || 0) * 100));
+  const labels = sorted.map(c => c.node || c.label || c.node_id || 'Unknown');
+  const shares = sorted.map(c => ((c.shapley_share ?? c.percentage_share ?? c.delta_share ?? 0) * 100));
   const colors = shares.map(v => v >= 0 ? Q.greenFill : Q.redFill);
   const borders = shares.map(v => v >= 0 ? Q.green : Q.red);
 
@@ -806,7 +836,8 @@ function pickNormalizedDelta(data) {
 <script>
 (function() {
   const rc = qdata.root_cause || {};
-  const score = rc.conclusion?.confidence_score;
+  const conclusion = getConfidenceConclusion(qdata);
+  const score = conclusion.confidence_score;
   if (score == null) { document.getElementById('confidence-section').classList.add('hidden'); return; }
 
   const pct = (score * 100).toFixed(0);
@@ -814,8 +845,8 @@ function pickNormalizedDelta(data) {
   el.textContent = pct + '%';
   el.className = 'score-display ' + (score >= 0.8 ? 'score-high' : score >= 0.6 ? 'score-medium' : 'score-low');
 
-  const present = rc.evidence_types_present || [];
-  const missing = rc.evidence_types_missing || [];
+  const present = rc.conclusion?.evidence_types_present || rc.evidence_types_present || [];
+  const missing = rc.conclusion?.evidence_types_missing || rc.evidence_types_missing || [];
   const container = document.getElementById('evidence-tags');
   present.forEach(t => {
     const span = document.createElement('span');

--- a/plugins/qluent/templates/render-charts.html
+++ b/plugins/qluent/templates/render-charts.html
@@ -425,10 +425,13 @@ function getTakeaways(data) {
         <div class="kpi-label">${esc(rootNode.label || ev.tree_label || 'Total')}</div>
       </div>`);
     getRootContributors(qdata).forEach(c => {
+      const shareLine = c.delta_share != null
+        ? `<div class="kpi-delta ${deltaClass(c.delta_share)}">${(c.delta_share * 100).toFixed(0)}% of change</div>`
+        : '';
       row.insertAdjacentHTML('beforeend', `
         <div class="kpi-card">
           <div class="kpi-value" style="font-size:1.15rem">${fmtCurrency(c.delta_value)}</div>
-          <div class="kpi-delta ${deltaClass(c.delta_share)}">${(c.delta_share * 100).toFixed(0)}% of change</div>
+          ${shareLine}
           <div class="kpi-label">${esc(c.label || c.node_id)}</div>
         </div>`);
     });

--- a/tests/test_renderer_contract.sh
+++ b/tests/test_renderer_contract.sh
@@ -40,6 +40,9 @@ assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
   'const present = rc.conclusion?.evidence_types_present || rc.evidence_types_present || [];'
 assert_not_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
   'qdata.root_cause?.top_contributors || []'
+# Guard against NaN% when a contributor has no delta_share (e.g. takeaway fallback)
+assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'c.delta_share != null'
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
@@ -101,14 +104,46 @@ assert_contains "$html" '"label": "Net Revenue"'
 assert_contains "$html" 'getRootNode(qdata)'
 assert_contains "$html" 'getRootContributors(qdata)'
 
+takeaway_only_json="$tmpdir/takeaway_only.json"
+takeaway_html="$tmpdir/takeaway.html"
+
+cat > "$takeaway_only_json" <<'JSON'
+{
+  "tree_id": "revenue",
+  "tree_label": "Revenue & Commercial",
+  "evaluation": {
+    "nodes": [
+      {
+        "id": "net_revenue",
+        "label": "Net Revenue",
+        "parent_id": null,
+        "current_value": 100,
+        "delta_value": 10,
+        "delta_ratio": 0.1
+      }
+    ]
+  },
+  "root_cause": {
+    "conclusion": {
+      "takeaways": [
+        {"kind": "driver", "node_id": "gross_revenue", "title": "Gross Revenue", "summary": "drove the change", "delta_value": 8}
+      ]
+    }
+  }
+}
+JSON
+
+"$ROOT/plugins/qluent/scripts/render-charts.sh" "$takeaway_only_json" "$takeaway_html" >/dev/null
+assert_contains "$takeaway_html" '"title": "Gross Revenue"'
+
 cat > "$contaminated_json" <<'TEXT'
 [qluent] awaiting response... (30s)
 {"tree_id":"revenue"}
 TEXT
 
-if "$ROOT/plugins/qluent/scripts/render-charts.sh" "$contaminated_json" "$tmpdir/bad.html" >/tmp/render.out 2>/tmp/render.err; then
+if "$ROOT/plugins/qluent/scripts/render-charts.sh" "$contaminated_json" "$tmpdir/bad.html" >"$tmpdir/render.out" 2>"$tmpdir/render.err"; then
   fail "render-charts.sh should reject contaminated non-JSON input"
 fi
-assert_contains /tmp/render.err "Input is not valid JSON"
+assert_contains "$tmpdir/render.err" "Input is not valid JSON"
 
 echo "renderer contract tests passed"

--- a/tests/test_renderer_contract.sh
+++ b/tests/test_renderer_contract.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file should contain: $needle"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file should not contain: $needle"
+  fi
+}
+
+assert_contains "$ROOT/plugins/qluent/commands/investigate.md" \
+  '--json-output | tee /tmp/qluent-viz-data.json'
+assert_not_contains "$ROOT/plugins/qluent/commands/investigate.md" \
+  '--json-output 2>&1 | tee /tmp/qluent-viz-data.json'
+
+assert_contains "$ROOT/plugins/qluent/agents/qluent-analyst.md" \
+  '--json-output | tee /tmp/qluent-viz-data.json'
+assert_not_contains "$ROOT/plugins/qluent/agents/qluent-analyst.md" \
+  '--json-output 2>&1 | tee /tmp/qluent-viz-data.json'
+
+assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'const rootNode = getRootNode(qdata);'
+assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'const contributors = getRootContributors(qdata);'
+assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'const present = rc.conclusion?.evidence_types_present || rc.evidence_types_present || [];'
+assert_not_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'qdata.root_cause?.top_contributors || []'
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+valid_json="$tmpdir/investigate.json"
+contaminated_json="$tmpdir/contaminated.json"
+html="$tmpdir/out.html"
+
+cat > "$valid_json" <<'JSON'
+{
+  "tree_id": "revenue",
+  "tree_label": "Revenue & Commercial",
+  "period_label": "Mar vs Feb",
+  "current_window": {"date_from": "2026-03-01", "date_to": "2026-03-31"},
+  "comparison_window": {"date_from": "2026-02-01", "date_to": "2026-02-28"},
+  "evaluation": {
+    "nodes": [
+      {
+        "id": "net_revenue",
+        "label": "Net Revenue",
+        "parent_id": null,
+        "current_value": 39090016.17,
+        "comparison_value": 31475112.41,
+        "delta_value": 7614903.76,
+        "delta_ratio": 0.2419,
+        "contributions": [
+          {"node_id": "gross_revenue", "label": "Gross Revenue", "delta_value": 7615633.11, "delta_share": 1.0001}
+        ]
+      },
+      {
+        "id": "gross_revenue",
+        "label": "Gross Revenue",
+        "parent_id": "net_revenue",
+        "current_value": 39093738.73,
+        "comparison_value": 31478105.62,
+        "delta_value": 7615633.11,
+        "delta_ratio": 0.2419
+      }
+    ],
+    "top_contributors": [
+      {"node_id": "gross_revenue", "label": "Gross Revenue", "delta_value": 7615633.11, "delta_share": 1.0001}
+    ]
+  },
+  "root_cause": {
+    "conclusion": {
+      "confidence_score": 0.9,
+      "evidence_types_present": ["driver", "time_slice"],
+      "evidence_types_missing": [],
+      "takeaways": [
+        {"kind": "driver", "title": "Gross Revenue", "summary": "Gross Revenue contributed +$7.62M"}
+      ]
+    }
+  }
+}
+JSON
+
+"$ROOT/plugins/qluent/scripts/render-charts.sh" "$valid_json" "$html" >/dev/null
+assert_contains "$html" '"label": "Net Revenue"'
+assert_contains "$html" 'getRootNode(qdata)'
+assert_contains "$html" 'getRootContributors(qdata)'
+
+cat > "$contaminated_json" <<'TEXT'
+[qluent] awaiting response... (30s)
+{"tree_id":"revenue"}
+TEXT
+
+if "$ROOT/plugins/qluent/scripts/render-charts.sh" "$contaminated_json" "$tmpdir/bad.html" >/tmp/render.out 2>/tmp/render.err; then
+  fail "render-charts.sh should reject contaminated non-JSON input"
+fi
+assert_contains /tmp/render.err "Input is not valid JSON"
+
+echo "renderer contract tests passed"


### PR DESCRIPTION
## Summary

- keep qluent JSON capture clean by removing `2>&1` from investigate examples
- make `render-charts.sh` validate JSON before generating HTML, so contaminated progress output fails loudly instead of rendering an empty shell
- update the fallback HTML template to bind to the current investigate payload shape (`evaluation.nodes`, root `contributions`, `evaluation.top_contributors`, and `root_cause.conclusion`)
- add a focused shell contract test for the renderer/docs behavior

## Why

Dogfood showed the fallback HTML page opening with empty cards because `/tmp/qluent-viz-data.json` could contain progress text and the template still looked for older fields such as `evaluation.current_value` and `root_cause.top_contributors`.

## Validation

- `bash tests/test_renderer_contract.sh`
- rendered a cleaned copy of the dogfood investigation payload through `render-charts.sh`
- verified contaminated JSON now fails with `Input is not valid JSON`
