### PR TITLE
release: bump plugin to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "Qluent"
       },

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qluent",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"


### PR DESCRIPTION
The marketplace cache is keyed by version string, so leaving 0.3.0 in plugin.json and marketplace.json makes /plugin marketplace update report "already at latest" even after new commits land. Bumping to 0.3.1 forces clients to refetch and pick up the renderer JSON-binding fix.