### PR TITLE
Add bump-version script and CI version-drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Verify version manifests are in sync
+        run: node scripts/bump-version.mjs --check
+      - name: Run renderer contract test
+        run: bash tests/test_renderer_contract.sh

--- a/README.md
+++ b/README.md
@@ -87,3 +87,34 @@ instead of falling back to separate tree investigations.
 ## License
 
 MIT
+
+## Contributing
+
+### Cutting a release
+
+The plugin version is tracked in two manifest files:
+
+- `.claude-plugin/marketplace.json` (both `metadata.version` and the
+  `plugins[].version` for the `qluent` entry)
+- `plugins/qluent/.claude-plugin/plugin.json`
+
+The marketplace cache key includes the version string, so the version field
+**must** be bumped for clients to pick up new commits — leaving it unchanged
+makes `/plugin marketplace update` short-circuit with "already at latest".
+
+To bump every manifest at once:
+
+```bash
+node scripts/bump-version.mjs 0.3.2
+```
+
+To verify all manifests share the same version (CI runs this on every PR):
+
+```bash
+node scripts/bump-version.mjs --check
+# or pin an expected value:
+node scripts/bump-version.mjs --check 0.3.2
+```
+
+Open a release PR with the bump commit, merge to `main`, and clients will pull
+the new version on their next `/plugin marketplace update qluent-metric-trees`.

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..');
+
+function parseArgs(argv) {
+  const args = { check: false, root: DEFAULT_ROOT, version: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--check') args.check = true;
+    else if (a === '--root') args.root = resolve(argv[++i]);
+    else if (a.startsWith('--root=')) args.root = resolve(a.slice('--root='.length));
+    else if (a === '-h' || a === '--help') {
+      printUsage();
+      process.exit(0);
+    } else if (!args.version) args.version = a;
+    else die(`Unexpected argument: ${a}`);
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node scripts/bump-version.mjs <version>          Bump every manifest to <version>.
+  node scripts/bump-version.mjs --check [version]  Verify all manifests share the same version.
+                                                   Pass <version> to require a specific value.
+
+Options:
+  --root <path>    Repository root (defaults to the parent of this script).`);
+}
+
+function die(msg) {
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    die(`Failed to read ${path}: ${err.message}`);
+  }
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+function targets(root) {
+  const marketplacePath = resolve(root, '.claude-plugin/marketplace.json');
+  const pluginPath = resolve(root, 'plugins/qluent/.claude-plugin/plugin.json');
+  return [
+    {
+      label: '.claude-plugin/marketplace.json (metadata.version)',
+      path: marketplacePath,
+      get: (j) => j.metadata?.version,
+      set: (j, v) => {
+        j.metadata = j.metadata || {};
+        j.metadata.version = v;
+      },
+    },
+    {
+      label: '.claude-plugin/marketplace.json (plugins[qluent].version)',
+      path: marketplacePath,
+      get: (j) => j.plugins?.find((p) => p.name === 'qluent')?.version,
+      set: (j, v) => {
+        const entry = j.plugins?.find((p) => p.name === 'qluent');
+        if (!entry) die('marketplace.json has no plugin entry named "qluent"');
+        entry.version = v;
+      },
+    },
+    {
+      label: 'plugins/qluent/.claude-plugin/plugin.json (version)',
+      path: pluginPath,
+      get: (j) => j.version,
+      set: (j, v) => {
+        j.version = v;
+      },
+    },
+  ];
+}
+
+function check(root, expected) {
+  const items = targets(root);
+  const versions = items.map((t) => ({ label: t.label, version: t.get(readJson(t.path)) }));
+  const distinct = new Set(versions.map((v) => v.version));
+
+  if (distinct.size !== 1) {
+    console.error('Error: version drift detected across manifests:');
+    versions.forEach((v) => console.error(`  ${v.label}: ${v.version ?? '(missing)'}`));
+    process.exit(1);
+  }
+
+  const [actual] = distinct;
+  if (!actual || !SEMVER.test(actual)) {
+    die(`Version "${actual}" is not a valid semver string`);
+  }
+  if (expected && actual !== expected) {
+    die(`Expected version "${expected}" but found "${actual}"`);
+  }
+  console.log(`OK: every manifest is at ${actual}`);
+}
+
+function bump(root, version) {
+  if (!SEMVER.test(version)) die(`"${version}" is not a valid semver string`);
+  const items = targets(root);
+  const seen = new Map();
+  for (const t of items) {
+    const json = seen.get(t.path) ?? readJson(t.path);
+    t.set(json, version);
+    seen.set(t.path, json);
+  }
+  for (const [path, json] of seen) writeJson(path, json);
+  console.log(`Bumped ${seen.size} file(s) to ${version}:`);
+  for (const path of seen.keys()) console.log(`  ${path}`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.check) check(args.root, args.version);
+else if (args.version) bump(args.root, args.version);
+else {
+  printUsage();
+  process.exit(1);
+}


### PR DESCRIPTION
The marketplace cache is keyed by version string, so every release needs the version bumped in both .claude-plugin/marketplace.json (metadata and plugin entry) and plugins/qluent/.claude-plugin/plugin.json. Hand-editing all three is error-prone and lets versions drift silently.

bump-version.mjs writes one version to every manifest at once, and its --check mode fails when the files disagree or differ from an expected value. CI runs --check on every PR (alongside the renderer contract test) so a drift can't merge.