### PR TITLE
refactor: enforce protocol locality via fitness function (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,5 @@ jobs:
         run: bash tests/test_renderer_contract.sh
       - name: Run command surface test
         run: bash tests/test_command_surface.sh
+      - name: Run protocol locality test
+        run: bash tests/test_protocol_locality.sh

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -70,7 +70,7 @@ For "why did this move?" questions:
 For elasticity / leverage / "what if":
 
 1. Read embedded `levers` first.
-2. Reuse the exact windows from the bundle.
+2. Use the bundle's windows per the skill.
 3. Run a deeper lever table only if needed:
    ```bash
    qluent trees levers <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
@@ -102,20 +102,11 @@ RCA+trend+compare triangulation, or segment pivot-and-synthesis.
 1. **Lead with the answer** — what changed and why, in one sentence.
 2. **Supporting evidence** — attribution, trend context, mechanism from the
    server response.
-3. **Confidence** — report the evidence-coverage score (never as a
-   probability).
+3. **Confidence** — present the returned evidence-coverage score per the skill.
 4. **Windows** — state the exact date ranges used.
 5. **Follow-ups** — 2-3 concrete next steps tailored to the data.
 6. **Gaps** — say so explicitly when something is unresolved.
 
-## Rules
-
-- Always pass an explicit `<tree_id>` to qluent commands; pick it client-side
-  via `qluent trees list --json-output`.
-- Always use `--json-output`.
-- If RCA times out on broad ranges, suggest quarterly breakdowns.
-- Report numbers from the qluent output — do not round, estimate, or invent.
-- Never parse tool-result temp files or write ad-hoc scripts against prior
-  bash output.
-- Do not rerun both JSON and non-JSON versions of the same command unless
-  JSON is genuinely insufficient.
+If RCA times out on broad ranges, suggest quarterly breakdowns. Every other
+rule about JSON output, tree-id discipline, provenance, and how to handle
+prior bash output lives in the `qluent-interpretation` skill.

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -127,14 +127,13 @@ backed by actual qluent fields:
 ### Provenance and evidence labels
 
 Every material section preserves provenance per the `qluent-interpretation`
-skill: command/result type, tree id/label, node id/label, segment
-dimension/value, exact current/comparison windows, materiality, and
-confidence/evidence coverage. Carry returned caveats (gaps, low confidence,
-sparse samples, missing dimensions, unsupported cuts, guardrail warnings,
-stale or unequal-length windows) into top-level `caveats[]`. Carry result
-references and data lineage into `sources[]`. Use returned evidence labels
-exactly when present: `observed_correlation`, `historical_elasticity`,
-`model_estimate`, `experiment_backed`.
+skill, mapped into the spec: per-section `data` carries command/result type,
+tree id/label, node/segment, exact windows, materiality, and
+confidence/evidence coverage. Returned caveats (gaps, low confidence, sparse
+samples, missing dimensions, unsupported cuts, guardrail warnings, stale or
+unequal-length windows) flow into top-level `caveats[]`. Result references
+and data lineage flow into `sources[]`. Use the returned evidence labels
+named in the skill exactly when present.
 
 ## Step 4: HTML fallback for local demos
 

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -30,8 +30,8 @@ client-side before any quantitative call.
    candidates with labels and descriptions. Use `AskUserQuestion` only when
    the caller has that tool; otherwise ask in plain text. Do not guess silently.
 
-Always pass an explicit `<tree_id>` to every qluent subcommand. Always use
-`--json-output`.
+Always pass an explicit `<tree_id>` to every qluent subcommand.
+Always use `--json-output`.
 
 ## Windows
 

--- a/tests/test_protocol_locality.sh
+++ b/tests/test_protocol_locality.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Architectural fitness test for protocol locality.
+# Enforces the resolution of #45: the qluent-interpretation skill is the deep
+# module — protocol rules live there, not restated across commands and agents.
+# Callers reference the skill instead of paraphrasing it.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL="$ROOT/plugins/qluent/skills/qluent-interpretation/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file should contain: $needle"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file should not contain (lives only in the skill): $needle"
+  fi
+}
+
+# Files that must defer to the skill instead of restating it.
+CALLERS=(
+  "$ROOT/plugins/qluent/commands/investigate.md"
+  "$ROOT/plugins/qluent/commands/deep-dive.md"
+  "$ROOT/plugins/qluent/commands/visualize.md"
+  "$ROOT/plugins/qluent/agents/qluent-analyst.md"
+  "$ROOT/plugins/qluent/agents/rca-validator.md"
+  "$ROOT/plugins/qluent/agents/trend-interpreter.md"
+  "$ROOT/plugins/qluent/agents/segment-explorer.md"
+  "$ROOT/plugins/qluent/CLAUDE.md"
+)
+
+# Canonical phrases that must live ONLY in the skill. Each phrase is the
+# distinctive wording of a protocol rule the skill owns.
+SKILL_ONLY_PHRASES=(
+  'Reuse the exact'
+  'Always use `--json-output`'
+  'Never parse tool-result temp files'
+  'back-calculate'
+  'cooperative game theory'
+  'Do not rerun both JSON and non-JSON'
+  'Confidence scores are evidence-coverage heuristics'
+)
+
+# Evidence-label list: the four-label vocabulary belongs in the skill. Callers
+# reference the skill — they do not enumerate the labels themselves.
+EVIDENCE_LABELS=(
+  'observed_correlation'
+  'historical_elasticity'
+  'model_estimate'
+  'experiment_backed'
+)
+
+# 1. Skill carries every canonical phrase.
+for phrase in "${SKILL_ONLY_PHRASES[@]}"; do
+  assert_contains "$SKILL" "$phrase"
+done
+for label in "${EVIDENCE_LABELS[@]}"; do
+  assert_contains "$SKILL" "$label"
+done
+
+# 2. No caller restates a canonical phrase.
+for caller in "${CALLERS[@]}"; do
+  for phrase in "${SKILL_ONLY_PHRASES[@]}"; do
+    assert_not_contains "$caller" "$phrase"
+  done
+  for label in "${EVIDENCE_LABELS[@]}"; do
+    assert_not_contains "$caller" "$label"
+  done
+done
+
+# 3. Every caller names the skill so the pointer is real.
+for caller in "${CALLERS[@]}"; do
+  assert_contains "$caller" 'qluent-interpretation'
+done
+
+# 4. Agents declare the load contract via frontmatter (#32 seam).
+for agent in qluent-analyst rca-validator trend-interpreter segment-explorer; do
+  agent_file="$ROOT/plugins/qluent/agents/${agent}.md"
+  # Crude but sufficient: the frontmatter line must appear.
+  if ! grep -E '^[[:space:]]*-[[:space:]]+qluent-interpretation[[:space:]]*$' "$agent_file" >/dev/null; then
+    fail "$agent_file frontmatter must list qluent-interpretation under skills:"
+  fi
+done
+
+# 5. Slash commands declare the load contract via Step 0 Read (#32 seam).
+#    setup.md is intentionally exempt — it predates any analysis flow.
+for cmd in investigate deep-dive visualize; do
+  cmd_file="$ROOT/plugins/qluent/commands/${cmd}.md"
+  assert_contains "$cmd_file" 'skills/qluent-interpretation/SKILL.md'
+done
+
+echo "protocol locality tests passed"

--- a/tests/test_protocol_locality.sh
+++ b/tests/test_protocol_locality.sh
@@ -29,16 +29,13 @@ assert_not_contains() {
 }
 
 # Files that must defer to the skill instead of restating it.
-CALLERS=(
-  "$ROOT/plugins/qluent/commands/investigate.md"
-  "$ROOT/plugins/qluent/commands/deep-dive.md"
-  "$ROOT/plugins/qluent/commands/visualize.md"
-  "$ROOT/plugins/qluent/agents/qluent-analyst.md"
-  "$ROOT/plugins/qluent/agents/rca-validator.md"
-  "$ROOT/plugins/qluent/agents/trend-interpreter.md"
-  "$ROOT/plugins/qluent/agents/segment-explorer.md"
-  "$ROOT/plugins/qluent/CLAUDE.md"
-)
+CALLERS=("$ROOT/plugins/qluent/CLAUDE.md")
+for caller in "$ROOT"/plugins/qluent/commands/*.md "$ROOT"/plugins/qluent/agents/*.md; do
+  case "$(basename "$caller")" in
+    setup.md) continue ;;
+  esac
+  CALLERS+=("$caller")
+done
 
 # Canonical phrases that must live ONLY in the skill. Each phrase is the
 # distinctive wording of a protocol rule the skill owns.
@@ -85,8 +82,7 @@ for caller in "${CALLERS[@]}"; do
 done
 
 # 4. Agents declare the load contract via frontmatter (#32 seam).
-for agent in qluent-analyst rca-validator trend-interpreter segment-explorer; do
-  agent_file="$ROOT/plugins/qluent/agents/${agent}.md"
+for agent_file in "$ROOT"/plugins/qluent/agents/*.md; do
   # Crude but sufficient: the frontmatter line must appear.
   if ! grep -E '^[[:space:]]*-[[:space:]]+qluent-interpretation[[:space:]]*$' "$agent_file" >/dev/null; then
     fail "$agent_file frontmatter must list qluent-interpretation under skills:"
@@ -95,8 +91,10 @@ done
 
 # 5. Slash commands declare the load contract via Step 0 Read (#32 seam).
 #    setup.md is intentionally exempt — it predates any analysis flow.
-for cmd in investigate deep-dive visualize; do
-  cmd_file="$ROOT/plugins/qluent/commands/${cmd}.md"
+for cmd_file in "$ROOT"/plugins/qluent/commands/*.md; do
+  case "$(basename "$cmd_file")" in
+    setup.md) continue ;;
+  esac
   assert_contains "$cmd_file" 'skills/qluent-interpretation/SKILL.md'
 done
 


### PR DESCRIPTION
## Summary

Closes #45. The `qluent-interpretation` skill is the canonical home for protocol — windows, `--json-output` discipline, provenance, Shapley framing, evidence labels, elasticity guardrails, unsupported-cut fallback. This PR locks that architecture in place via an **architectural fitness function** and removes the residual restatements that survived the prior consolidation.

## What was the actual scope

Going into this, I expected #45 to be a wide refactor — every command and agent restating protocol. On a fresh grep of `main`, only two files still carried load-bearing restatements:

- **`agents/qluent-analyst.md`** — a "Rules" section paraphrasing the skill (`--json-output`, no-temp-file-parsing, no-double-rerun, "evidence-coverage score (never as a probability)").
- **`commands/visualize.md`** — enumerating the four evidence labels instead of pointing at the skill.

Plus one cosmetic: the skill itself had `Always use` / `` `--json-output` `` split across a line break, which made the rule harder for a fitness test (or a human) to locate.

The earlier work (#32 establishing the load contract; the consolidations on `main` in #50) had already done the heavy lifting. The deepening that remained is small — and that's an honest outcome. The architectural win in this PR is **the test**, not the line count.

## Changes

- **Added** `tests/test_protocol_locality.sh` — fitness function asserting:
  1. The skill carries every canonical protocol phrase (positive assertions).
  2. No caller (`commands/*.md`, `agents/*.md`, `CLAUDE.md`) restates one (negative assertions).
  3. Every caller names the skill, so the seam to the deep module is real.
  4. Every agent's frontmatter declares `skills: qluent-interpretation` (load contract from #32).
  5. Every analysis slash command's Step 0 explicitly Reads the skill (also #32's load contract).
- **Removed** the duplicated Rules section in `qluent-analyst.md`; one operational rule (RCA timeouts → quarterly breakdowns) survives inline. The rest defers to the skill.
- **Replaced** the paraphrase "evidence-coverage score (never as a probability)" with "evidence-coverage score per the skill."
- **Replaced** the four-label enumeration in `visualize.md` Step 3 with a skill reference.
- **Reformatted** the skill's `--json-output` rule onto one line so it stays locatable.
- **Wired** the new test into `.github/workflows/ci.yml`.

Diff: 5 files changed, +119/−24 (most of the +119 is the new test file).

## Methodology — TDD per #45's acceptance plan

1. Wrote `tests/test_protocol_locality.sh` with positive + negative assertions; ran it → red on `qluent-analyst.md`'s `Always use \`--json-output\`` paraphrase.
2. Reformatted the skill, removed restatements, replaced enumerations with skill references.
3. Re-ran → green.
4. Wired into CI alongside `test_command_surface.sh` and `test_renderer_contract.sh`.

The test catches future drift: any new command or agent that paraphrases a protocol rule, or fails to declare its load contract (frontmatter for agents, Step 0 for commands), breaks CI.

## Test plan

- [x] `bash tests/test_protocol_locality.sh` passes locally
- [x] `bash tests/test_command_surface.sh` still passes
- [x] `bash tests/test_renderer_contract.sh` still passes
- [x] `node scripts/bump-version.mjs --check` still passes
- [ ] CI runs all four checks on this branch

## Design choices (locked in this PR)

Per the grilling discussion before cutting code:

1. **Step 0 boilerplate stays per-command.** Slash commands still each open with `Read ${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md`. That's the load contract from #32, doing real work; not duplication. Kept simple — no shared loader, no session-start injection, no clever indirection.
2. **Hybrid bash split.** Each command keeps its primary `qluent` invocation; cross-cutting conventions (`--json-output`, `\| tee /tmp/...`) live in the skill. A new flag for `qluent trees investigate` → edit `investigate.md`. A new convention → edit the skill.

These match the "long-term but simple" brief.

## Out of scope

This PR is **only** Candidate 1 / #45. Sibling issues remain open:

- #46 — own the `/tmp/qluent-*.json` rendezvous (still magic strings; deferred to its own PR)
- #47 — consolidate the unsupported-cut fallback algorithm (three implementations remain on main)
- #49 — split README.md / CLAUDE.md / skill seams by audience (CLAUDE.md still has visualization-precedence content the skill also owns; #49 finishes that thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnpanE9A19UjaZcuKQKFk2)_