### PR TITLE
refactor: consolidate unsupported-cut fallback algorithm into one canonical script (#47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,5 @@ jobs:
         run: bash tests/test_command_surface.sh
       - name: Run protocol locality test
         run: bash tests/test_protocol_locality.sh
+      - name: Run fallback algorithm test
+        run: bash tests/test_fallback_algorithm.sh

--- a/plugins/qluent/agents/segment-explorer.md
+++ b/plugins/qluent/agents/segment-explorer.md
@@ -37,19 +37,16 @@ For supported dimensions, run RCA on the original tree:
 qluent rca analyze <tree_id> --current <start>:<end> --compare <start>:<end> --json-output
 ```
 
-For unsupported dimensions, pick the closest compatible companion tree. Prefer:
-
-1. Full coverage of every requested dimension.
-2. Most overlapping dimensions.
-3. Root-metric family tiebreak.
-
-Run segmentation on the companion tree with the exact same windows:
+For unsupported dimensions, apply the unsupported-cut selection algorithm
+documented in the `qluent-interpretation` skill against the cached catalog,
+then run segmentation on the chosen companion tree with the exact same
+windows:
 
 ```bash
 qluent rca analyze <companion_tree_id> --current <start>:<end> --compare <start>:<end> --json-output
 ```
 
-When the catalog has no compatible tree, say so and stop. Do not invent
+When the algorithm returns no candidate, say so and stop. Do not invent
 dimensions or fabricate rankings.
 
 ## Synthesis

--- a/plugins/qluent/scripts/post-bash.sh
+++ b/plugins/qluent/scripts/post-bash.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 jq_bin=$(command -v jq || true)
 [ -n "$jq_bin" ] || exit 0
 
@@ -81,9 +83,8 @@ build_fallback_guidance() {
   [ -f "$viz_path" ] || return 0
   "$jq_bin" -e 'type == "object"' "$viz_path" >/dev/null 2>&1 || return 0
 
-  local tree_id tree_label status current_from current_to comparison_from comparison_to
+  local tree_id status current_from current_to comparison_from comparison_to
   tree_id=$("$jq_bin" -r '.tree_id // empty' "$viz_path")
-  tree_label=$("$jq_bin" -r '.tree_label // empty' "$viz_path")
   status=$("$jq_bin" -r '.agent.status // empty' "$viz_path")
   current_from=$("$jq_bin" -r '.current_window.date_from // empty' "$viz_path")
   current_to=$("$jq_bin" -r '.current_window.date_to // empty' "$viz_path")
@@ -139,66 +140,33 @@ build_fallback_guidance() {
     window_args="--current ${current_from}:${current_to} --compare ${comparison_from}:${comparison_to}"
   fi
 
-  local required_json='[]'
-  if [ ${#unsupported_dims[@]} -gt 0 ]; then
-    required_json=$(printf '%s\n' "${unsupported_dims[@]}" | "$jq_bin" -R . | "$jq_bin" -s .)
-  fi
+  local required_csv
+  required_csv=$(join_by ',' "${unsupported_dims[@]}")
 
-  local -a compatible_candidates=()
-  local -a partial_candidates=()
-  local line candidate_id candidate_dims
-
-  if [ -f "$catalog_path" ]; then
-    while IFS=$'\t' read -r candidate_id candidate_dims; do
-      [ -n "$candidate_id" ] && compatible_candidates+=("${candidate_id} (segments: ${candidate_dims})")
-    done < <(
-      "$jq_bin" -r --arg current "$tree_id" --argjson required "$required_json" '
-        .trees[]?
-        | select(.id != $current)
-        | (.dims // .dimensions // []) as $dims
-        | select(($required | all(. as $req | $dims | index($req))))
-        | [.id, ($dims | join(", "))] | @tsv
-      ' "$catalog_path"
-    )
-
-    if [ ${#compatible_candidates[@]} -eq 0 ]; then
-      while IFS=$'\t' read -r candidate_id candidate_dims; do
-        [ -n "$candidate_id" ] && partial_candidates+=("${candidate_id} (segments: ${candidate_dims})")
-      done < <(
-        "$jq_bin" -r --arg current "$tree_id" --argjson required "$required_json" '
-          [
-            .trees[]?
-            | select(.id != $current)
-            | (.dims // .dimensions // []) as $dims
-            | {
-                id: .id,
-                dims: ($dims | join(", ")),
-                overlap: ($required | map(select($dims | index(.))) | length)
-              }
-            | select(.overlap > 0)
-          ]
-          | sort_by(-.overlap, .id)[]
-          | [.id, .dims] | @tsv
-        ' "$catalog_path"
-      )
-    fi
-  fi
+  local selector="${SCRIPT_DIR}/select-fallback-tree.sh"
+  local selection selected_id selected_reason selected_dims=""
+  selection=$("$selector" "$catalog_path" "$tree_id" "$required_csv" 2>/dev/null || printf '\tnone\t')
+  selected_id=$(printf '%s' "$selection" | cut -f1)
+  selected_reason=$(printf '%s' "$selection" | cut -f2)
+  selected_dims=$(printf '%s' "$selection" | cut -f3)
 
   echo "  → Requested segment cuts are unavailable on ${tree_id:-this tree}: $(join_by ', ' "${unsupported_dims[@]}")."
   echo "  → Keep the same windows and pivot to the closest tree that supports the missing cuts. Do not stop at the limitation."
 
-  if [ ${#compatible_candidates[@]} -gt 0 ]; then
-    echo "  → Compatible fallback trees from session context: $(join_by ', ' "${compatible_candidates[@]:0:3}")"
-    if [ -n "$window_args" ]; then
-      line="${compatible_candidates[0]}"
-      candidate_id="${line%% *}"
-      echo "  → Example next step: qluent trees investigate ${candidate_id} ${window_args} --json-output"
-    fi
-  elif [ ${#partial_candidates[@]} -gt 0 ]; then
-    echo "  → No tree covers every requested cut, but these trees cover part of it: $(join_by ', ' "${partial_candidates[@]:0:3}")"
-  else
-    echo "  → No compatible fallback tree is cached yet. Run \`qluent trees list --json-output\`, choose a tree exposing those dimensions, and continue with the same windows."
-  fi
+  case "$selected_reason" in
+    full_coverage)
+      echo "  → Closest companion tree: ${selected_id} (segments: ${selected_dims})."
+      if [ -n "$window_args" ]; then
+        echo "  → Example next step: qluent trees investigate ${selected_id} ${window_args} --json-output"
+      fi
+      ;;
+    partial_overlap)
+      echo "  → No tree covers every requested cut. Best partial match: ${selected_id} (segments: ${selected_dims})."
+      ;;
+    *)
+      echo "  → No compatible fallback tree is cached yet. Run \`qluent trees list --json-output\`, choose a tree exposing those dimensions, and continue with the same windows."
+      ;;
+  esac
 
   echo "  → Synthesize both views: keep the original tree for KPI-specific or category/margin reasoning, and use the fallback tree for the requested segmentation."
 

--- a/plugins/qluent/scripts/select-fallback-tree.sh
+++ b/plugins/qluent/scripts/select-fallback-tree.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Select the closest companion tree when the requested segment cuts are not
+# supported on the current tree. This is the single source of truth for the
+# unsupported-cut fallback ranking; the post-bash hook calls it to surface
+# nudges, and the skill (qluent-interpretation) names it as the canonical
+# implementation.
+#
+# Usage:
+#   select-fallback-tree.sh <catalog_path> <current_tree_id> <required_dims_csv>
+#
+# Output (single TSV line on stdout):
+#   <tree_id>\t<reason>\t<comma_separated_dims>
+#
+# Reasons:
+#   full_coverage   — chosen tree exposes every requested dimension
+#   partial_overlap — chosen tree exposes a subset (best available)
+#   none            — no other tree exposes any of the requested dimensions
+#                     (or the catalog is missing/unreadable)
+#
+# Ranking (matches the skill's documented algorithm):
+#   1. Full coverage wins.
+#   2. Most overlapping dimensions wins.
+#   3. Tiebreak: same root-metric family as the current tree.
+#   4. Final tiebreak: alphabetical tree id.
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+  echo "usage: $0 <catalog_path> <current_tree_id> <required_dims_csv>" >&2
+  exit 2
+fi
+
+catalog_path="$1"
+current_tree="$2"
+required_csv="$3"
+
+jq_bin=$(command -v jq || true)
+if [ -z "$jq_bin" ]; then
+  echo "select-fallback-tree.sh requires jq" >&2
+  exit 2
+fi
+
+if [ ! -f "$catalog_path" ]; then
+  printf '\tnone\t\n'
+  exit 0
+fi
+
+required_json=$(printf '%s' "$required_csv" | "$jq_bin" -R 'split(",") | map(select(length > 0))')
+
+current_root=$("$jq_bin" -r --arg id "$current_tree" '
+  .trees[]? | select(.id == $id) | (.root // .root_metric // "")
+' "$catalog_path" | head -n 1)
+
+"$jq_bin" -r \
+  --arg current "$current_tree" \
+  --arg current_root "$current_root" \
+  --argjson required "$required_json" '
+  ($required | length) as $needed
+  | [
+      .trees[]?
+      | select(.id != $current)
+      | (.dims // .dimensions // []) as $dims
+      | (.root // .root_metric // "") as $root
+      | ($required | map(select(IN($dims[]))) | length) as $overlap
+      | select($overlap > 0)
+      | {
+          id: .id,
+          dims: ($dims | join(",")),
+          overlap: $overlap,
+          full: ($overlap == $needed),
+          family: ($root == $current_root and $current_root != "")
+        }
+    ]
+  | sort_by([
+      -(.full | if . then 1 else 0 end),
+      -.overlap,
+      -(.family | if . then 1 else 0 end),
+      .id
+    ])
+  | if length == 0 then
+      "\tnone\t"
+    else
+      .[0] as $best
+      | "\($best.id)\t\(if $best.full then "full_coverage" else "partial_overlap" end)\t\($best.dims)"
+    end
+' "$catalog_path"

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -83,8 +83,7 @@ for t in trees:
         line += '  (' + ' | '.join(meta) + ')'
     print(line)
 print()
-print('Fallback rule: if a requested cut is unavailable on the chosen tree, keep the same windows and pivot to the closest tree that lists that dimension.')
-print('Combine the original tree for KPI-specific explanation with the fallback tree for segmentation instead of stopping at the limitation.')
+print('Unsupported cuts: the post-bash hook surfaces the closest companion tree per the algorithm in the qluent-interpretation skill. Follow its suggestion and synthesize both views.')
 print()
 print('Business-language routing hints: revenue/sales/GMV/AOV -> revenue; growth/users/acquisition/reactivation -> growth; delivery/late/failed/courier/ops quality -> operations; conversion/checkout/cart/traffic/payment -> conversion_funnel.')
 print('On first run, orient the user from this tree metadata and offer one concrete first command. Use qluent whoami/status/suggestions only when available; do not probe unsupported project/status commands.')

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -130,17 +130,35 @@ block is insufficient.
 
 ## Unsupported segment cuts
 
-If the user asks for a dimension the current tree does not expose:
+If the user asks for a dimension the current tree does not expose, pivot to a
+compatible companion tree with the same windows and synthesize both views.
 
-1. Reuse the exact current/comparison windows from the prior result.
-2. Check the session tree catalog (or run `qluent trees list --json-output`)
-   for a compatible tree that declares the missing dimension.
-3. Re-run the investigation or RCA on the fallback tree with the same windows.
-4. Synthesize both views: original tree for KPI-specific reasoning, fallback
-   tree for the requested segmentation. State which tree provided which view.
+### Selection algorithm
 
-Never stop at the limitation. The PostToolUse hook surfaces compatible
-fallback trees automatically — follow its suggestions.
+Given the cached catalog (`/tmp/qluent-tree-capabilities.json`, or a fresh
+`qluent trees list --json-output`), the current tree id, and the requested
+dimensions, rank candidates as follows:
+
+1. **Full coverage wins.** Among trees that declare *every* requested
+   dimension, prefer the best.
+2. **Otherwise, most overlapping dimensions wins.** Among trees that expose at
+   least one requested dimension, prefer the highest count.
+3. **Tiebreak — Root-metric family tiebreak.** Within either group, prefer
+   trees that share the current tree's root metric.
+4. **Final tiebreak: alphabetical tree id.**
+5. **No candidate? Stop and say so.** Do not invent or fabricate.
+
+This is the single source of truth for the algorithm. The PostToolUse hook
+runs `scripts/select-fallback-tree.sh` to surface the chosen tree to the
+user; agents that decide pre-emptively (e.g. `segment-explorer`) apply the
+same algorithm against the cached catalog.
+
+### Synthesis
+
+Combine both views: the original tree for KPI-specific reasoning, the
+companion tree for the requested segmentation. State which tree provided
+which view. Reuse the exact current/comparison windows from the prior
+result; never stop at the limitation.
 
 ## Visualization
 

--- a/tests/test_fallback_algorithm.sh
+++ b/tests/test_fallback_algorithm.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Architectural fitness + behavior tests for the unsupported-cut fallback
+# algorithm. Enforces the resolution of #47:
+#   1. The ranking lives in exactly one place: scripts/select-fallback-tree.sh.
+#   2. The skill names the algorithm; callers (post-bash hook, segment-explorer
+#      agent, CLAUDE.md, session-start) defer to it instead of restating it.
+#   3. Behavior tests pin the ranking decisions against synthetic catalogs.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/plugins/qluent/scripts/select-fallback-tree.sh"
+SKILL="$ROOT/plugins/qluent/skills/qluent-interpretation/SKILL.md"
+HOOK="$ROOT/plugins/qluent/scripts/post-bash.sh"
+AGENT="$ROOT/plugins/qluent/agents/segment-explorer.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected [$expected], got [$actual]"
+  fi
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file should contain: $needle"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file should not contain (algorithm lives in the skill + script): $needle"
+  fi
+}
+
+# 1. The script exists and is executable.
+[ -x "$SCRIPT" ] || fail "select-fallback-tree.sh must exist and be executable"
+
+# 2. Behavior tests against synthetic catalogs.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Catalog A: tree_full has every requested dim → full_coverage.
+cat > "$tmpdir/catalog_full.json" <<'JSON'
+{"trees":[
+  {"id":"current","root":"revenue","dims":["region"]},
+  {"id":"tree_full","root":"orders","dims":["region","channel","cohort"]},
+  {"id":"tree_partial","root":"orders","dims":["region","channel"]}
+]}
+JSON
+out=$("$SCRIPT" "$tmpdir/catalog_full.json" "current" "channel,cohort")
+assert_eq "tree_full" "$(printf '%s' "$out" | cut -f1)" "full_coverage selection"
+assert_eq "full_coverage" "$(printf '%s' "$out" | cut -f2)" "full_coverage reason"
+
+# Catalog B: no tree covers all dims; tree_high_overlap covers more than tree_low_overlap.
+cat > "$tmpdir/catalog_partial.json" <<'JSON'
+{"trees":[
+  {"id":"current","root":"revenue","dims":["region"]},
+  {"id":"tree_high_overlap","root":"orders","dims":["region","channel"]},
+  {"id":"tree_low_overlap","root":"orders","dims":["region","platform"]}
+]}
+JSON
+out=$("$SCRIPT" "$tmpdir/catalog_partial.json" "current" "channel,cohort,platform")
+assert_eq "tree_high_overlap" "$(printf '%s' "$out" | cut -f1)" "partial_overlap selection (highest count)"
+assert_eq "partial_overlap" "$(printf '%s' "$out" | cut -f2)" "partial_overlap reason"
+
+# Catalog C: no overlap at all → none.
+cat > "$tmpdir/catalog_none.json" <<'JSON'
+{"trees":[
+  {"id":"current","root":"revenue","dims":["region"]},
+  {"id":"tree_unrelated","root":"orders","dims":["foo","bar"]}
+]}
+JSON
+out=$("$SCRIPT" "$tmpdir/catalog_none.json" "current" "channel,cohort")
+assert_eq "" "$(printf '%s' "$out" | cut -f1)" "none selection"
+assert_eq "none" "$(printf '%s' "$out" | cut -f2)" "none reason"
+
+# Catalog D: tiebreak — same overlap count, family wins over non-family.
+cat > "$tmpdir/catalog_family.json" <<'JSON'
+{"trees":[
+  {"id":"current","root":"revenue","dims":["region"]},
+  {"id":"tree_other_family","root":"orders","dims":["region","channel"]},
+  {"id":"tree_same_family","root":"revenue","dims":["region","channel"]}
+]}
+JSON
+out=$("$SCRIPT" "$tmpdir/catalog_family.json" "current" "channel")
+assert_eq "tree_same_family" "$(printf '%s' "$out" | cut -f1)" "family tiebreak wins"
+
+# Catalog E: tiebreak — same overlap, same family, alphabetical id wins.
+cat > "$tmpdir/catalog_alpha.json" <<'JSON'
+{"trees":[
+  {"id":"current","root":"revenue","dims":["region"]},
+  {"id":"tree_z","root":"revenue","dims":["region","channel"]},
+  {"id":"tree_a","root":"revenue","dims":["region","channel"]}
+]}
+JSON
+out=$("$SCRIPT" "$tmpdir/catalog_alpha.json" "current" "channel")
+assert_eq "tree_a" "$(printf '%s' "$out" | cut -f1)" "alphabetical tiebreak wins"
+
+# Catalog F: missing catalog file → none, exit 0.
+out=$("$SCRIPT" "$tmpdir/does-not-exist.json" "current" "channel" || true)
+assert_eq "none" "$(printf '%s' "$out" | cut -f2)" "missing catalog returns none"
+
+# 3. Drift assertions: ranking-distinctive phrases live only in the skill +
+#    the script implementing them. The agent, CLAUDE.md, and session-start.sh
+#    must reference, not restate.
+RANKING_PHRASES=(
+  'Full coverage'
+  'most overlapping'
+  'Root-metric family tiebreak'
+)
+DRIFT_TARGETS=(
+  "$AGENT"
+  "$ROOT/plugins/qluent/CLAUDE.md"
+  "$ROOT/plugins/qluent/scripts/session-start.sh"
+)
+for target in "${DRIFT_TARGETS[@]}"; do
+  for phrase in "${RANKING_PHRASES[@]}"; do
+    assert_not_contains "$target" "$phrase"
+  done
+done
+
+# 4. The skill carries the canonical algorithm.
+for phrase in "${RANKING_PHRASES[@]}"; do
+  assert_contains "$SKILL" "$phrase"
+done
+assert_contains "$SKILL" 'select-fallback-tree.sh'
+
+# 5. The hook delegates to the script (no inline ranking jq).
+assert_contains "$HOOK" 'select-fallback-tree.sh'
+# The two characteristic field names from the previous inline impl should be
+# gone — they were the ranking logic's local variable names.
+assert_not_contains "$HOOK" 'compatible_candidates'
+assert_not_contains "$HOOK" 'partial_candidates'
+
+echo "fallback algorithm tests passed"


### PR DESCRIPTION
## Summary

Closes #47. Consolidates the unsupported-cut fallback ranking algorithm — previously implemented three ways with documented drift between them — into a single canonical script with behavior tests.

## What was actually wrong

The pre-refactor state had three implementations of the same idea, and they had already drifted:

- **`scripts/post-bash.sh`** had an inline jq filter ranking compatible vs partial candidates. The partial-overlap branch was **buggy**: `select($dims | index(.))` rebinds `.` to `$dims`, so every iteration computed `["region","channel"] | index(["region","channel"])` and returned 0 — every candidate appeared to fully match every required dimension. CI tests catch this in the new behavior suite (Catalog B asserts a partial-overlap selection that was previously misclassified as full coverage).
- **`agents/segment-explorer.md`** prose listed `"Full coverage / Most overlapping / Root-metric family tiebreak"` — a tiebreaker the shell never implemented.
- **`scripts/session-start.sh`** printed a paraphrase of the fallback rule into session context.

Three places, three slightly different versions, no behavior tests. Classic shallow duplication.

## Design — Option C from #47 (extracted shared script)

Picked **Option C** because behavior tests need an isolated entry point, and the script is small enough (~50 lines) that the indirection pays for itself immediately:

- **`plugins/qluent/scripts/select-fallback-tree.sh`** — one canonical jq-driven implementation. Args: catalog path, current tree id, required dims CSV. Output: TSV `<tree_id>\t<reason>\t<dims_csv>` where reason ∈ {`full_coverage`, `partial_overlap`, `none`}. Implements the documented algorithm (full coverage > overlap count > same root-metric family > alphabetical id) and uses the `IN` operator to fix the inherited `index(.)` bug.
- **`scripts/post-bash.sh`** — `build_fallback_guidance()` now calls the script and presents one suggestion instead of a top-3 list. ~50 lines of inline jq + bash gone.
- **`skills/qluent-interpretation/SKILL.md`** — "Unsupported segment cuts" section names the algorithm precisely (input, ranking rules, tiebreakers) and points at `scripts/select-fallback-tree.sh` as the canonical implementation.
- **`agents/segment-explorer.md`** — drops the algorithm prose, defers to the skill.
- **`scripts/session-start.sh`** — drops the rule paraphrase, points at the hook + skill.

The hook is the *executable* adapter; the agent (which decides pre-emptively before its second RCA call) is the *runtime-decision* adapter. Two adapters → real seam, per DEEPENING.md.

## Changes

- **Added** `plugins/qluent/scripts/select-fallback-tree.sh` — extracted ranking
- **Added** `tests/test_fallback_algorithm.sh` — behavior tests + drift assertions
- **Updated** `plugins/qluent/scripts/post-bash.sh` — call the script, drop inline jq + 4 bash arrays
- **Updated** `plugins/qluent/agents/segment-explorer.md` — drop algorithm list, reference skill
- **Updated** `plugins/qluent/scripts/session-start.sh` — drop rule paraphrase, point at hook
- **Updated** `plugins/qluent/skills/qluent-interpretation/SKILL.md` — full algorithm spec with named ranking rules
- **Wired** the new test in `.github/workflows/ci.yml`

Diff: 7 files changed, +293/−78 (most of +293 is the test + the new script + the deeper skill section).

## Test plan

Behavior tests against five synthetic catalogs:
1. **Full coverage** — one tree exposes every requested dim → returns it with `full_coverage`.
2. **Partial overlap** — no tree covers all dims; highest-overlap wins.
3. **None** — no overlap → empty selection with `none`.
4. **Family tiebreak** — equal overlap, the tree sharing the current tree's root metric wins.
5. **Alphabetical tiebreak** — equal overlap and same family → alphabetical id wins.

Plus drift assertions:
- The ranking-distinctive phrases (`Full coverage`, `most overlapping`, `Root-metric family tiebreak`) appear in the skill but **not** in the agent, CLAUDE.md, or session-start.sh.
- The hook references `select-fallback-tree.sh`.
- `compatible_candidates` and `partial_candidates` (the previous local-variable names from the inline impl) are gone from the hook.

- [x] `bash tests/test_fallback_algorithm.sh` passes locally (red on missing script, then on each refactor step, then green)
- [x] `bash tests/test_protocol_locality.sh` still passes
- [x] `bash tests/test_command_surface.sh` still passes
- [x] `bash tests/test_renderer_contract.sh` still passes
- [x] `node scripts/bump-version.mjs --check` still passes
- [ ] CI runs all five checks on this branch

## Open question to flag

The script's "same root-metric family" tiebreak uses **exact root match** (e.g. `revenue == revenue`). A richer notion (`revenue` and `orders` both being "commerce" family) would need either a domain-knowledge config in the catalog or hard-coded mappings in the script. Exact match is what was implementable from today's catalog schema — happy to revisit if/when the catalog grows a `family` field.

## Out of scope

- The catalog file path itself (`/tmp/qluent-tree-capabilities.json`) is still a magic string referenced from multiple places — that's #46.
- CLAUDE.md still has its visualization-precedence content — that's #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnpanE9A19UjaZcuKQKFk2)_