### PR TITLE
refactor: own /tmp/qluent-*.json rendezvous via skill declaration + allowlist test (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,5 @@ jobs:
         run: bash tests/test_command_surface.sh
       - name: Run protocol locality test
         run: bash tests/test_protocol_locality.sh
+      - name: Run session paths test
+        run: bash tests/test_session_paths.sh

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -9,8 +9,9 @@ When the user mentions metrics, KPIs, business performance, or seems unsure
 what to ask, offer to help.
 
 The session-start hook (`scripts/session-start.sh`) is the canonical source for
-per-session orientation. It introspects available trees, writes the catalog file
-at `/tmp/qluent-tree-capabilities.json`, and injects:
+per-session orientation. It introspects available trees, writes the session
+tree catalog (see Session paths in the `qluent-interpretation` skill), and
+injects:
 
 - the list of available trees with root metrics, sub-metric breakdowns, and segment dimensions
 - business-language routing hints (for example, revenue/GMV -> `revenue`, conversion/cart -> `conversion_funnel`)
@@ -70,8 +71,9 @@ outcome-shaped `RcaReportSpec` with ordered `sections[]`, `caveats[]`, and
 used. Local HTML is a fallback only on `--simple`/`--html` or when the UI
 contract is unavailable; use `render-charts.sh` for that path.
 
-All qluent analysis commands pipe through `tee /tmp/qluent-viz-data.json` so
-`/qluent:visualize` is immediately available.
+All qluent analysis commands pipe through the canonical investigation cache
+(see Session paths in the `qluent-interpretation` skill) so `/qluent:visualize`
+is immediately available.
 
 ## Cross-tree deep dives
 

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -154,3 +154,41 @@ See `/qluent:visualize` for the section mapping (`root_movement`,
 `driver_decomposition`, `material_segment_scan`, `mix_shift`,
 `elasticity_summary`, `next_drills`) and the `dashboard-design` skill for HTML
 fallback styling.
+
+## Session paths
+
+Three temp files form the rendezvous between qluent producers and consumers
+within a session. This section is the canonical declaration; every producer,
+consumer, and test fixture references the path string verbatim. The set of
+files allowed to mention each path is pinned by `tests/test_session_paths.sh`
+— adding a new consumer requires updating that allowlist on purpose.
+
+### `/tmp/qluent-viz-data.json` — investigation cache
+- **Producer:** `/qluent:investigate` (and `qluent-analyst`) tee bundled
+  investigation JSON to this path.
+- **Consumers:** `/qluent:visualize` reads it to build `RcaReportSpec`;
+  `scripts/post-bash.sh` inspects it to surface unsupported-cut nudges and
+  freshness reminders; `scripts/render-charts.sh` reads it for the HTML
+  fallback.
+- **Schema:** the full investigate response, including `tree_id`,
+  `tree_label`, `current_window`, `comparison_window`, `agent`, `evaluation`,
+  `root_cause`, `levers`, `validation`, `warnings`.
+- **Freshness:** consumers should verify `current_window.date_from` is recent
+  and the `tree_id` matches the question before rendering. Stale or
+  mismatched data triggers a re-run suggestion.
+
+### `/tmp/qluent-deep-dive-bundle.json` — cross-tree deep-dive bundle
+- **Producer:** `/qluent:deep-dive` tees the bundled cross-tree JSON to this
+  path.
+- **Consumer:** `scripts/post-bash.sh` checks for it and steers synthesis
+  toward one cross-tree narrative.
+- **Schema:** bundle-level period/windows plus per-tree results per
+  `qluent trees deep-dive --json-output`.
+
+### `/tmp/qluent-tree-capabilities.json` — session tree catalog
+- **Producer:** `scripts/session-start.sh` writes the normalized catalog
+  (tree id, label, root metric, dimensions, children) at session start.
+- **Consumers:** `scripts/post-bash.sh` and `scripts/select-fallback-tree.sh`
+  read it for the unsupported-cut algorithm; `segment-explorer` and
+  `rca-validator` agents read it to pick companion trees pre-emptively.
+- **Schema:** `{"trees": [{"id", "label", "root", "desc", "dims", "children"}, ...]}`.

--- a/tests/test_session_paths.sh
+++ b/tests/test_session_paths.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Architectural fitness test for the canonical session-path rendezvous.
+# Enforces the resolution of #46: each canonical /tmp/qluent-* path appears
+# in exactly the documented allowlist of files. Any addition or removal
+# requires updating this allowlist (a forcing function for "do we want a
+# new consumer?" decisions).
+#
+# The qluent-interpretation skill is the single canonical declaration; every
+# other entry in each list is a real producer, consumer, or test fixture.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL="$ROOT/plugins/qluent/skills/qluent-interpretation/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file should contain: $needle"
+}
+
+# Find every file containing the given literal path. Returns repo-relative
+# paths sorted alphabetically.
+find_references() {
+  local needle="$1"
+  grep -rlF "$needle" \
+      --include='*.md' --include='*.sh' --include='*.yml' --include='*.json' \
+      "$ROOT/plugins" "$ROOT/tests" "$ROOT/README.md" 2>/dev/null \
+    | while read -r f; do echo "${f#$ROOT/}"; done \
+    | sort
+}
+
+# Assert the set of files referencing $path matches $allowlist exactly.
+check_path() {
+  local path="$1"
+  shift
+  local expected
+  expected=$(printf '%s\n' "$@" | sort)
+  local actual
+  actual=$(find_references "$path")
+
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: Allowlist drift for path '$path'" >&2
+    echo "  Expected:" >&2
+    printf '    %s\n' "$@" | sort >&2
+    echo "  Actual:" >&2
+    printf '    %s\n' $actual >&2
+    echo "  If you intentionally added or removed a reference, update the" >&2
+    echo "  allowlist in tests/test_session_paths.sh and the Session paths" >&2
+    echo "  section in qluent-interpretation/SKILL.md." >&2
+    exit 1
+  fi
+}
+
+# 1. Skill has the canonical Session paths section that names each path.
+assert_contains "$SKILL" '## Session paths'
+assert_contains "$SKILL" '/tmp/qluent-viz-data.json'
+assert_contains "$SKILL" '/tmp/qluent-deep-dive-bundle.json'
+assert_contains "$SKILL" '/tmp/qluent-tree-capabilities.json'
+
+# 2. Allowlist enforcement.
+check_path '/tmp/qluent-viz-data.json' \
+  'plugins/qluent/agents/qluent-analyst.md' \
+  'plugins/qluent/commands/investigate.md' \
+  'plugins/qluent/commands/visualize.md' \
+  'plugins/qluent/scripts/post-bash.sh' \
+  'plugins/qluent/scripts/render-charts.sh' \
+  'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_renderer_contract.sh' \
+  'tests/test_session_paths.sh'
+
+check_path '/tmp/qluent-deep-dive-bundle.json' \
+  'plugins/qluent/commands/deep-dive.md' \
+  'plugins/qluent/scripts/post-bash.sh' \
+  'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_session_paths.sh'
+
+check_path '/tmp/qluent-tree-capabilities.json' \
+  'plugins/qluent/agents/rca-validator.md' \
+  'plugins/qluent/agents/segment-explorer.md' \
+  'plugins/qluent/scripts/post-bash.sh' \
+  'plugins/qluent/scripts/session-start.sh' \
+  'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_session_paths.sh'
+
+echo "session paths tests passed"


### PR DESCRIPTION
## Summary

Closes #46. Gives the `/tmp/qluent-*.json` rendezvous between qluent producers and consumers an explicit owner, via a canonical declaration in the skill plus an allowlist-driven fitness function that prevents silent drift.

## Design decision — Option A (docs-only seam)

The issue offered three options:
- **A.** Skill names the contract; paths stay as literal strings in callers.
- **B.** Sourced shell helper (`scripts/session-paths.sh`) exporting env vars.
- **C.** Hybrid (helper + skill section).

Picked **A**. Reasons:
- Claude reads literal paths from prose more reliably than `${QLUENT_VIZ_DATA}`-style indirection. Mixing modes (some files literal, some var) is more confusing than the duplication it eliminates.
- The user typing `cat /tmp/qluent-viz-data.json` interactively (without sourcing the helper) is a normal workflow — env-var indirection breaks it.
- Per-session uniqueness, freshness checks, and GC are bigger architectural questions (`CLAUDE_SESSION_ID` availability, schema versioning, cleanup hooks) — each deserves its own design conversation if/when needed. This PR doesn't preclude any of them.
- The "long-term yet simple" brief: the architectural win is having **one canonical declaration** of what each path holds, not eliminating the literal string from caller files.

## Changes

- **Added `## Session paths`** to `plugins/qluent/skills/qluent-interpretation/SKILL.md`. Documents each path's producer, consumers, schema, and freshness contract:
  - `/tmp/qluent-viz-data.json` — investigation cache (produced by `/qluent:investigate`, consumed by `/qluent:visualize`, the post-bash hook, and `render-charts.sh`)
  - `/tmp/qluent-deep-dive-bundle.json` — cross-tree deep-dive bundle
  - `/tmp/qluent-tree-capabilities.json` — session tree catalog
- **Added `tests/test_session_paths.sh`** — allowlist-driven fitness function. Each path's set of referencing files must equal the documented allowlist exactly. Adding a new consumer requires updating both the skill section and the test allowlist on purpose. The test fails with a clear "if you intentionally added or removed a reference, update the allowlist" message.
- **Trimmed `plugins/qluent/CLAUDE.md`** — the two literal path mentions become pointers to the skill's Session paths section.
- **Wired** the new test in `.github/workflows/ci.yml`.

Diff: 4 files changed, +137/−4 (most of +137 is the new section + the test).

## TDD methodology

1. Wrote `tests/test_session_paths.sh` first → red on the missing `## Session paths` heading in the skill.
2. Added the section with full documentation of each path.
3. Re-ran → red on `CLAUDE.md` containing the literal paths (allowlist drift).
4. Trimmed CLAUDE.md to use skill pointers.
5. Re-ran → green.
6. Wired into CI.

## Test plan

- [x] `bash tests/test_session_paths.sh` passes locally
- [x] `bash tests/test_protocol_locality.sh` still passes
- [x] `bash tests/test_command_surface.sh` still passes
- [x] `bash tests/test_renderer_contract.sh` still passes
- [x] `node scripts/bump-version.mjs --check` still passes
- [ ] CI runs all five checks on this branch

## What was deliberately *not* changed

- The literal strings still live in producer/consumer files. They have to — bash needs the path. The fitness function constrains *who's allowed to mention them*, not where they appear.
- Per-session uniqueness (`/tmp/qluent-viz-data-${CLAUDE_SESSION_ID}.json`): deferred. `CLAUDE_SESSION_ID` availability in command/hook context is unverified, and parallel-session collisions haven't been observed as a current pain point. If they become one, the skill section is the natural home for the new path scheme.
- Schema-version tagging: deferred. Useful if the JSON shape ever changes; would land in the same skill section.
- Garbage collection: deferred. Would be a session-end hook; doesn't need a session-paths refactor as a prerequisite.

## Out of scope

- Touching paths in PRs #51 (#45) or #52 (#47) — both are still open. If either merges first, this PR will need a trivial rebase.
- The CLAUDE.md / README.md / skill seam split — that's #49 (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnpanE9A19UjaZcuKQKFk2)_