### PR TITLE
refactor: split README / CLAUDE.md / skill seams by audience (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,5 @@ jobs:
         run: bash tests/test_command_surface.sh
       - name: Run protocol locality test
         run: bash tests/test_protocol_locality.sh
+      - name: Run doc seams test
+        run: bash tests/test_doc_seams.sh

--- a/README.md
+++ b/README.md
@@ -55,32 +55,17 @@ bundled response calls for them.
 
 ## Cross-tree deep dives
 
-`/qluent:deep-dive [period]` calls:
-
-```bash
-qluent trees deep-dive --json-output --period "<period>"
-```
-
-The CLI runs investigations across all configured trees in parallel and returns one
-bundled JSON payload. Claude then synthesizes the bundle into a single narrative with:
-
-- **Headline** — which root metrics moved
-- **Concentration** — segments that show up across trees
-- **Mechanism** — whether the movement looks like volume, basket, conversion, mix,
-  operational quality, cost, margin, or timing
-- **Caveats** — errored trees, skipped cuts, low confidence, or sparse data
-- **Next-best drills** — ranked, copy-pasteable `/qluent:*` follow-up commands
-
-Because this can run several investigations at once, the command confirms before
-execution. Use `--yes` for autonomous mode after you have decided the cost is acceptable:
+`/qluent:deep-dive [period]` runs investigations across every configured tree
+in parallel and returns one bundled narrative. It confirms cost before
+running unless you pass `--yes`:
 
 ```bash
 /qluent:deep-dive "last week" --yes
 ```
 
 Requires a qluent CLI release that includes `qluent trees deep-dive` from
-`qluent-cli#40`. Older CLIs are detected and the command exits with an upgrade warning
-instead of falling back to separate tree investigations.
+`qluent-cli#40`. See `/qluent:deep-dive` for the full workflow contract,
+including the synthesis shape and per-tree caveat handling.
 
 ## License
 

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -62,22 +62,12 @@ interpretation, elasticity guardrails, and the segment-cut fallback rule live
 in the `qluent-interpretation` skill. Read it before driving the CLI; do not
 restate or paraphrase its rules elsewhere.
 
-## Visualization
+## Visualization and deep-dives
 
-For charts and RCA reports, use `/qluent:visualize`. It produces an
-outcome-shaped `RcaReportSpec` with ordered `sections[]`, `caveats[]`, and
-`sources[]`. Do not hand-roll HTML/CSS/Chart.js when the UI contract can be
-used. Local HTML is a fallback only on `--simple`/`--html` or when the UI
-contract is unavailable; use `render-charts.sh` for that path.
-
-All qluent analysis commands pipe through `tee /tmp/qluent-viz-data.json` so
-`/qluent:visualize` is immediately available.
-
-## Cross-tree deep dives
-
-`/qluent:deep-dive [period]` runs `qluent trees deep-dive --json-output --period`
-(qluent-cli#40+). It is opt-in and confirms cost unless `--yes` is passed.
-Synthesize the bundle into one narrative — never split into per-tree reports.
+Visualization precedence (`RcaReportSpec` first, HTML fallback) and
+cross-tree deep-dive synthesis are owned by `/qluent:visualize`,
+`/qluent:deep-dive`, and the `qluent-interpretation` skill. Follow them; do
+not restate their workflows here.
 
 ## Agents
 

--- a/tests/test_doc_seams.sh
+++ b/tests/test_doc_seams.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Architectural fitness test for the README / CLAUDE.md / qluent-interpretation
+# skill seams. Enforces the resolution of #49: each document has one audience
+# and one job, with no overlap.
+#
+#   README.md                          → users: install, quickstart, commands, release.
+#   plugins/qluent/CLAUDE.md           → agents: proactive guidance + pointers.
+#   .../skills/qluent-interpretation/  → protocol: rules, conventions, algorithms.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README="$ROOT/README.md"
+CLAUDE="$ROOT/plugins/qluent/CLAUDE.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file should contain: $needle"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file should not contain (this concern lives in a different doc by audience): $needle"
+  fi
+}
+
+# 1. README owns user onboarding.
+assert_contains "$README" 'npm install -g @qluent/cli'
+assert_contains "$README" '/plugin marketplace add qluent/qluent-plugin-cc'
+
+# 2. README does not own the cross-tree deep-dive narrative shape — that lives
+#    in commands/deep-dive.md as the workflow contract for the model.
+assert_not_contains "$README" 'Concentration** — segments that show up'
+assert_not_contains "$README" 'Mechanism** — whether the movement'
+assert_not_contains "$README" 'Next-best drills** — ranked'
+
+# 3. CLAUDE.md owns agent orientation and references the skill.
+assert_contains "$CLAUDE" 'qluent-interpretation'
+
+# 4. CLAUDE.md does not own user onboarding.
+assert_not_contains "$CLAUDE" 'npm install'
+assert_not_contains "$CLAUDE" 'qluent login'
+
+# 5. CLAUDE.md does not own the visualization precedence rule (the skill's
+#    Visualization section owns it).
+assert_not_contains "$CLAUDE" 'Do not hand-roll HTML/CSS/Chart.js'
+assert_not_contains "$CLAUDE" 'Local HTML is a fallback only on'
+
+# 6. CLAUDE.md does not own deep-dive synthesis instructions (the deep-dive
+#    command and the skill own those).
+assert_not_contains "$CLAUDE" 'Synthesize the bundle into one narrative'
+assert_not_contains "$CLAUDE" 'never split into per-tree reports'
+
+echo "doc seams tests passed"


### PR DESCRIPTION
## Summary

Closes #49. Splits the three documents by audience so each one has one job:

- **`README.md`** — users: install, quickstart, command table, release procedure.
- **`plugins/qluent/CLAUDE.md`** — agents: proactive guidance + pointers.
- **`qluent-interpretation` skill** — protocol, exclusively (already true; this PR doesn't touch the skill).

## What was overlapping

- **README** restated the entire cross-tree deep-dive narrative shape (`Headline / Concentration / Mechanism / Caveats / Next-best drills`) that already lives in `commands/deep-dive.md` as the workflow contract for the model.
- **CLAUDE.md** restated the visualization precedence rule (`Do not hand-roll HTML/CSS/Chart.js when the UI contract can be used`) that the skill's `## Visualization` section already owns.
- **CLAUDE.md** restated the deep-dive synthesis pointer (`Synthesize the bundle into one narrative — never split into per-tree reports`) that `/qluent:deep-dive` owns.

These weren't egregious, but they were three places to forget when a rule changed.

## Changes

- **`README.md`** — cross-tree section trimmed from a 23-line block (with bash + narrative bullets + caveats) to a 9-line pointer at `/qluent:deep-dive`. The detailed workflow stays in the command, where the model reads it.
- **`plugins/qluent/CLAUDE.md`** — the `## Visualization` and `## Cross-tree deep dives` sections collapsed into one short `## Visualization and deep-dives` pointer at the relevant commands + the skill.
- **`tests/test_doc_seams.sh`** — architectural fitness function:
  - README must contain install + marketplace-add lines (positive).
  - README must not contain deep-dive narrative section names (negative).
  - CLAUDE.md must reference the skill (positive).
  - CLAUDE.md must not contain user-onboarding strings (`npm install`, `qluent login`) — those belong in README.
  - CLAUDE.md must not contain the visualization-precedence rule details — those belong in the skill.
  - CLAUDE.md must not contain deep-dive synthesis instructions — those belong in the deep-dive command and the skill.
- **`.github/workflows/ci.yml`** — wires the new test.

Diff: 4 files changed, +74/−35.

## TDD methodology

1. Wrote `tests/test_doc_seams.sh` first → red on README containing `Concentration** — segments that show up`.
2. Trimmed the README cross-tree section.
3. Re-ran → red on CLAUDE.md containing `Do not hand-roll HTML/CSS/Chart.js`.
4. Trimmed the CLAUDE.md Visualization + Cross-tree sections.
5. Re-ran → green.
6. Wired into CI.

## Test plan

- [x] `bash tests/test_doc_seams.sh` passes locally
- [x] `bash tests/test_protocol_locality.sh` still passes
- [x] `bash tests/test_command_surface.sh` still passes
- [x] `bash tests/test_renderer_contract.sh` still passes
- [x] `node scripts/bump-version.mjs --check` still passes
- [ ] CI runs all five checks on this branch

## Pragmatic notes

- `Shapley` still appears in the README tagline (`an answer backed by Shapley attribution — not vibes`). That's marketing copy establishing technical credibility, not protocol restatement. The test deliberately doesn't ban it; it bans the *detailed rule phrasings* that drift if duplicated.
- The CLAUDE.md `## Capabilities to surface` list is **kept**. It's agent orientation — what the plugin can do at a glance — not command behavior repetition. Removing it would make first-turn proactive suggestions less reliable.

## Out of scope

- This PR does not touch the skill. Sibling PRs #51 (#45) and #53 (#46) are still open and modify the skill; if either lands first, this PR doesn't conflict because we only edit README and CLAUDE.md.
- PR #52 (#47) modifies CLAUDE.md? No — it only touches the agent, hook, skill, and session-start. So the only PR-pair with potential CLAUDE.md merge conflict is #53 (#46), and even there the conflict is benign (#46 turns one literal path into a pointer in CLAUDE.md; this PR removes the entire surrounding section). Whichever lands first, the other rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnpanE9A19UjaZcuKQKFk2)_