### PR TITLE
[codex] Fix deep-dive bundle visualization

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -70,6 +70,10 @@ cross-tree deep-dive synthesis are owned by `/qluent:visualize`,
 `/qluent:deep-dive`, and the `qluent-interpretation` skill. Follow them; do
 not restate their workflows here.
 
+Single-tree qluent analysis commands pipe stdout through `tee /tmp/qluent-viz-data.json`
+so `/qluent:visualize` is immediately available. Deep-dive commands write clean stdout
+JSON to `/tmp/qluent-deep-dive-bundle.json`; never redirect stderr into either JSON file.
+
 ## Agents
 
 - **`qluent-analyst`** — Orchestrator. Handles KPI questions autonomously and

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -106,8 +106,12 @@ investigates all configured trees in parallel.
 Run the deterministic bundled command and save the JSON bundle for this session:
 
 ```bash
-qluent trees deep-dive --json-output --period "<period>" 2>&1 | tee /tmp/qluent-deep-dive-bundle.json
+qluent trees deep-dive --json-output --period "<period>" | tee /tmp/qluent-deep-dive-bundle.json
 ```
+
+Keep stderr out of the saved bundle. Progress, usage text, and CLI errors must remain
+on stderr so `/tmp/qluent-deep-dive-bundle.json` round-trips through `jq .` and the
+renderer can validate it as clean JSON.
 
 If qluent exits non-zero:
 

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -27,6 +27,11 @@ By default, read from `/tmp/qluent-viz-data.json`. If the user provides `--file 
 that path instead. If the file doesn't exist or is empty, tell the user to run
 `/qluent:investigate` first.
 
+If `/tmp/qluent-deep-dive-bundle.json` exists and the user asks to visualize a
+deep-dive or cross-tree result, use that file instead. Deep-dive bundles must be clean
+JSON with a bundle-level `trees[]` array; if validation fails, report the failing path
+and re-run command instead of hand-writing replacement HTML.
+
 **Freshness check:** Read the file and verify `current_window.date_from` is recent. If the
 data looks stale (wrong tree, old dates), warn the user and suggest re-running investigate.
 
@@ -35,7 +40,8 @@ data looks stale (wrong tree, old dates), warn the user and suggest re-running i
 **Report spec mode** (strict default for deterministic RCA/elasticity output): Produce or
 request an outcome-shaped `RcaReportSpec` with `outcomeShape`, ordered `sections[]`,
 `caveats[]`, and `sources[]`. Use this when the JSON contains `root_cause`, `evaluation`,
-`levers`, `agent.recommended_next_steps`, `mix_shift`, or segment findings.
+`levers`, `agent.recommended_next_steps`, `mix_shift`, segment findings, or a deep-dive
+bundle with `trees[]`.
 
 Do not hand-roll report HTML when the UI report contract can be used. Preserve the
 deterministic qluent values and provenance in the spec instead of translating findings
@@ -73,12 +79,15 @@ Read the JSON data and map the deterministic qluent fields into an ordered repor
 
 ```ts
 {
-  outcomeShape: 'driver_concentration' | 'mix_shift' | 'elasticity_tradeoff' | 'data_quality_blocker' | string,
+  outcomeShape: 'driver_concentration' | 'mix_shift' | 'elasticity_tradeoff' | 'data_quality_blocker' | 'cross_tree_bundle' | string,
   sections: [
     { type: 'root_movement', data: ... },
     { type: 'driver_decomposition', data: ... },
     { type: 'material_segment_scan', data: ... },
     { type: 'mix_shift', data: ... },
+    { type: 'cross_tree_root_movement', data: ... },
+    { type: 'cross_tree_hotspot_grid', data: ... },
+    { type: 'cross_tree_overlap', data: ... },
     { type: 'elasticity_summary', data: ... },
     { type: 'next_drills', data: ... }
   ],
@@ -99,6 +108,8 @@ Choose `outcomeShape` from the strongest returned evidence:
   tradeoff, guardrail, or scenario estimate.
 - `data_quality_blocker`: qluent returns missing, stale, sparse, or low-confidence
   evidence that blocks a reliable interpretation.
+- `cross_tree_bundle`: a deep-dive bundle compares multiple trees in one result and
+  needs a cross-tree summary before any per-tree drill-down sections.
 - Use a specific string only when the UI contract supports it or the returned qluent
   payload names an outcome shape.
 
@@ -123,6 +134,20 @@ backed by actual qluent fields:
    the returned response explicitly supports stronger causal language.
 6. `next_drills`: `agent.recommended_next_steps`, unresolved gaps, validation drills,
    comparison suggestions, or tests needed before action.
+
+For `cross_tree_bundle`, put the cross-tree sections first and reuse single-tree section
+types only as subordinate drill-downs:
+
+1. `cross_tree_root_movement`: one row per tree with root metric label, current value,
+   comparison value, absolute movement, percentage movement, blocker/status, and tree id.
+2. `cross_tree_hotspot_grid`: segment, dimension, tree, contribution/effect, materiality,
+   and direction for returned concentrated segment or hotspot findings.
+3. `cross_tree_overlap`: shared segments, repeated dimensions, correlated/tensioned tree
+   movements, or an explicit "no overlap returned" state when the bundle lacks overlap.
+4. `driver_decomposition`: per-tree driver details below the cross-tree summary.
+5. `mix_shift`: per-tree or cross-tree mix-shift findings from returned bundle fields.
+6. `next_drills`: copy-pasteable returned or derived follow-up commands, preserving tree
+   ids, period, and dimensions.
 
 ### Provenance and evidence labels
 

--- a/plugins/qluent/scripts/render-charts.sh
+++ b/plugins/qluent/scripts/render-charts.sh
@@ -24,12 +24,30 @@ perl -MJSON::PP -0777 -e '
   open my $json_fh, "<", $input or die "Error: Cannot read input file: $input\n";
   my $json = <$json_fh>;
   close $json_fh;
-  eval { JSON::PP->new->decode($json); 1 } or do {
+  my $decoder = JSON::PP->new;
+  my $data;
+  eval { $data = $decoder->decode($json); 1 } or do {
     my $err = $@ || "unknown parse error";
     print STDERR "Error: Input is not valid JSON: $input\n";
+    if ($json =~ /\S/) {
+      my ($first) = $json =~ /\A\s*([^\r\n]+)/;
+      $first =~ s/^\s+|\s+$//g;
+      my $preview = substr($first, 0, 96);
+      print STDERR "  Diagnosis: expected JSON at line 1, found: $preview\n";
+      print STDERR "  Re-run with clean stdout capture, for example:\n";
+      print STDERR "  qluent trees deep-dive --json-output --period \"<period>\" > /tmp/qluent-deep-dive-bundle.json\n";
+    }
     print STDERR "  $err";
     exit 1;
   };
+  if (ref($data) eq "HASH" && ($data->{outcomeShape} || "") eq "cross_tree_bundle") {
+    if (ref($data->{trees}) ne "ARRAY") {
+      print STDERR "Error: Deep-dive bundle failed validation: expected bundle.trees[]\n";
+      print STDERR "  Contract pointer: trees\n";
+      print STDERR "  Re-run with: qluent trees deep-dive --json-output --period \"<period>\" > /tmp/qluent-deep-dive-bundle.json\n";
+      exit 1;
+    }
+  }
 ' "$INPUT"
 
 perl -0777 -e '

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -177,9 +177,10 @@ fallback styling.
 
 Three temp files form the rendezvous between qluent producers and consumers
 within a session. This section is the canonical declaration; every producer,
-consumer, and test fixture references the path string verbatim. The set of
-files allowed to mention each path is pinned by `tests/test_session_paths.sh`
-— adding a new consumer requires updating that allowlist on purpose.
+consumer, test fixture, and the plugin-level `CLAUDE.md` surface references
+the path string verbatim. The set of files allowed to mention each path is
+pinned by `tests/test_session_paths.sh` — adding a new consumer requires
+updating that allowlist on purpose.
 
 ### `/tmp/qluent-viz-data.json` — investigation cache
 - **Producer:** `/qluent:investigate` (and `qluent-analyst`) tee bundled

--- a/plugins/qluent/templates/render-charts.html
+++ b/plugins/qluent/templates/render-charts.html
@@ -262,6 +262,46 @@
     padding: 40px;
     font-size: 0.9rem;
   }
+  .data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+  }
+  .data-table th {
+    text-align: left;
+    color: #6b7280;
+    font-weight: 600;
+    border-bottom: 1px solid #e8e8ef;
+    padding: 8px 6px;
+  }
+  .data-table td {
+    color: #374151;
+    border-bottom: 1px solid #f3f4f6;
+    padding: 9px 6px;
+    vertical-align: top;
+  }
+  .data-table tr:last-child td { border-bottom: none; }
+  .pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 8px;
+    background: #f3f4f6;
+    color: #6b7280;
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .deep-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 720px) {
+    .deep-grid { grid-template-columns: 1fr; }
+    .main { padding: 24px 14px 48px; }
+    .data-table { font-size: 0.72rem; }
+  }
   .hidden { display: none; }
 </style>
 </head>
@@ -389,6 +429,67 @@ function getConfidenceConclusion(data) {
 function getTakeaways(data) {
   return data?.root_cause?.conclusion?.takeaways || [];
 }
+function isDeepDiveBundle(data) {
+  return Array.isArray(data?.trees);
+}
+function firstPresent(...values) {
+  return values.find(v => v != null && v !== '');
+}
+function unwrapTree(tree) {
+  return tree?.result || tree?.analysis || tree?.payload || tree || {};
+}
+function getTreeRoot(tree) {
+  const data = unwrapTree(tree);
+  return firstPresent(data.root_movement, data.root, data.evaluation?.root, data.evaluation?.root_metric)
+    || (data.evaluation?.nodes || []).find(n => n.parent_id === null)
+    || {};
+}
+function getTreeStatus(tree) {
+  const data = unwrapTree(tree);
+  if (tree?.error || data?.error) return 'error';
+  return firstPresent(tree?.status, data?.status, data?.agent?.status, 'ok');
+}
+function collectDeepDiveHotspots(data) {
+  const direct = firstPresent(data.hotspots, data.segment_hotspots, data.concentrated_segments, data.cross_tree_hotspots);
+  const rows = Array.isArray(direct) ? direct.map(h => ({...h})) : [];
+  (data.trees || []).forEach(tree => {
+    const tdata = unwrapTree(tree);
+    const treeLabel = firstPresent(tree.tree_label, tree.label, tdata.tree_label, tdata.tree_id, tree.tree_id);
+    const findings = [
+      ...(tdata.root_cause?.findings || []),
+      ...(tdata.segment_findings || []),
+      ...(tdata.hotspots || [])
+    ];
+    findings.forEach(f => {
+      const segments = f.segment_findings || f.segments || (f.segment ? [f] : []);
+      segments.forEach(s => rows.push({
+        tree_label: treeLabel,
+        dimension: firstPresent(s.dimension, s.segment_dimension, f.dimension),
+        segment: firstPresent(s.segment, s.segment_value, s.value, f.segment),
+        contribution: firstPresent(s.contribution, s.delta_value, s.effect_value, f.contribution),
+        materiality: firstPresent(s.materiality, s.share, s.delta_share, f.materiality),
+        direction: firstPresent(s.direction, f.direction)
+      }));
+    });
+  });
+  return rows.filter(h => firstPresent(h.segment, h.segment_value, h.dimension, h.tree_label));
+}
+function collectDeepDiveOverlap(data) {
+  const direct = firstPresent(data.overlap, data.cross_tree_overlap, data.shared_segments, data.correlations);
+  if (Array.isArray(direct)) return direct;
+  if (direct && typeof direct === 'object') return Object.values(direct).flat().filter(Boolean);
+  return [];
+}
+function collectDeepDiveCaveats(data) {
+  const caveats = [...(data.caveats || []), ...(data.gaps || [])];
+  (data.trees || []).forEach(tree => {
+    const tdata = unwrapTree(tree);
+    const label = firstPresent(tree.tree_label, tree.label, tdata.tree_label, tree.tree_id, tdata.tree_id, 'Tree');
+    [...(tdata.caveats || []), ...(tdata.gaps || []), ...(tdata.agent?.gaps || [])].forEach(c => caveats.push(label + ': ' + c));
+    if (tree.error || tdata.error) caveats.push(label + ': ' + (tree.error || tdata.error));
+  });
+  return caveats;
+}
 </script>
 
 <div class="main">
@@ -407,6 +508,13 @@ function getTakeaways(data) {
 
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) {
+    const label = qdata.title || qdata.period_label || 'Cross-tree Deep Dive';
+    document.getElementById('dash-title').textContent = label;
+    document.getElementById('dash-period').textContent = firstPresent(qdata.period, qdata.period_label, qdata.current_window?.date_from && qdata.current_window?.date_to ? qdata.current_window.date_from + ' to ' + qdata.current_window.date_to : '');
+    document.querySelector('.topbar .page-title').textContent = 'Cross-tree Deep Dive';
+    return;
+  }
   const label = qdata.tree_label || qdata.tree_id || 'Metric';
   document.getElementById('dash-title').textContent = label + ' Analysis';
   document.getElementById('dash-period').textContent = qdata.period_label || '';
@@ -461,6 +569,151 @@ function getTakeaways(data) {
 })();
 </script>
 
+<!-- Cross-tree deep-dive bundle -->
+<div class="card hidden" id="deep-dive-section">
+  <h2>Cross-tree Root Movement</h2>
+  <div class="sub">Bundle-level summary mapped from <code>trees[]</code></div>
+  <div style="overflow-x:auto;">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Tree</th>
+          <th>Root metric</th>
+          <th>Current</th>
+          <th>Comparison</th>
+          <th>Movement</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody id="deep-root-rows"></tbody>
+    </table>
+  </div>
+</div>
+
+<div class="deep-grid hidden" id="deep-detail-grid">
+  <div class="card" id="deep-hotspots-card">
+    <h2>Segment Hotspots</h2>
+    <div class="sub">Concentrated segment findings across trees</div>
+    <div id="deep-hotspots"></div>
+  </div>
+  <div class="card" id="deep-overlap-card">
+    <h2>Cross-tree Overlap</h2>
+    <div class="sub">Shared segments, repeated dimensions, or explicit gaps</div>
+    <div id="deep-overlap"></div>
+  </div>
+</div>
+
+<div class="card hidden" id="deep-drivers-section">
+  <h2>Driver Decomposition</h2>
+  <div class="sub">Per-tree top drivers from the bundle</div>
+  <div id="deep-drivers"></div>
+</div>
+
+<div class="card hidden" id="deep-caveats-section">
+  <h2>Caveats and Next Drills</h2>
+  <div id="deep-caveats"></div>
+</div>
+
+<script>
+(function() {
+  if (!isDeepDiveBundle(qdata)) return;
+
+  const rootRows = document.getElementById('deep-root-rows');
+  qdata.trees.forEach(tree => {
+    const data = unwrapTree(tree);
+    const root = getTreeRoot(tree);
+    const treeLabel = firstPresent(tree.tree_label, tree.label, data.tree_label, tree.tree_id, data.tree_id, 'Tree');
+    const deltaRatio = firstPresent(root.delta_ratio, root.percentage_change, data.delta_ratio);
+    const deltaValue = firstPresent(root.delta_value, root.absolute_change, data.delta_value);
+    rootRows.insertAdjacentHTML('beforeend', `
+      <tr>
+        <td>${esc(treeLabel)}</td>
+        <td>${esc(firstPresent(root.label, root.name, root.id, data.root_metric_label, 'Root metric'))}</td>
+        <td>${fmtCurrency(firstPresent(root.current_value, data.current_value))}</td>
+        <td>${fmtCurrency(firstPresent(root.comparison_value, root.compare_value, data.comparison_value))}</td>
+        <td><span class="${deltaClass(deltaValue)}">${fmtCurrency(deltaValue)}</span>${deltaRatio != null ? '<br>' + esc(fmtPctFlexible(deltaRatio)) : ''}</td>
+        <td><span class="pill">${esc(String(getTreeStatus(tree)).replace(/_/g, ' '))}</span></td>
+      </tr>`);
+  });
+  document.getElementById('deep-dive-section').classList.remove('hidden');
+
+  const hotspots = collectDeepDiveHotspots(qdata);
+  const hotspotsEl = document.getElementById('deep-hotspots');
+  if (hotspots.length) {
+    hotspotsEl.innerHTML = '<table class="data-table"><thead><tr><th>Tree</th><th>Segment</th><th>Dimension</th><th>Effect</th></tr></thead><tbody>'
+      + hotspots.slice(0, 12).map(h => `
+        <tr>
+          <td>${esc(firstPresent(h.tree_label, h.tree, h.tree_id, 'Cross-tree'))}</td>
+          <td>${esc(firstPresent(h.segment, h.segment_value, h.value, 'Segment'))}</td>
+          <td>${esc(firstPresent(h.dimension, h.segment_dimension, 'Dimension'))}</td>
+          <td>${esc(firstPresent(h.summary, h.direction, h.materiality != null ? fmtPctFlexible(h.materiality) : null, h.contribution != null ? fmtCurrency(h.contribution) : null, 'Returned'))}</td>
+        </tr>`).join('')
+      + '</tbody></table>';
+  } else {
+    hotspotsEl.innerHTML = '<div class="finding-item">No segment hotspots were returned in this bundle.</div>';
+  }
+
+  const overlap = collectDeepDiveOverlap(qdata);
+  const overlapEl = document.getElementById('deep-overlap');
+  if (overlap.length) {
+    overlap.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'finding-item';
+      div.textContent = typeof item === 'string' ? item : firstPresent(item.summary, item.description, item.segment, JSON.stringify(item));
+      overlapEl.appendChild(div);
+    });
+  } else {
+    overlapEl.innerHTML = '<div class="finding-item">No cross-tree overlap was returned in this bundle.</div>';
+  }
+  document.getElementById('deep-detail-grid').classList.remove('hidden');
+
+  const driversEl = document.getElementById('deep-drivers');
+  qdata.trees.forEach(tree => {
+    const data = unwrapTree(tree);
+    const treeLabel = firstPresent(tree.tree_label, tree.label, data.tree_label, tree.tree_id, data.tree_id, 'Tree');
+    const drivers = getRootContributors(data).slice(0, 5);
+    if (!drivers.length) return;
+    const h = document.createElement('div');
+    h.className = 'section-heading';
+    h.textContent = treeLabel;
+    driversEl.appendChild(h);
+    drivers.forEach(driver => {
+      const div = document.createElement('div');
+      div.className = 'finding-item';
+      div.textContent = firstPresent(driver.summary, driver.label, driver.node_id, 'Driver')
+        + (driver.delta_value != null ? ' ' + fmtCurrency(driver.delta_value) : '')
+        + (driver.delta_share != null ? ' (' + (driver.delta_share * 100).toFixed(0) + '% of change)' : '');
+      driversEl.appendChild(div);
+    });
+  });
+  if (driversEl.children.length) document.getElementById('deep-drivers-section').classList.remove('hidden');
+
+  const caveatsEl = document.getElementById('deep-caveats');
+  collectDeepDiveCaveats(qdata).forEach(c => {
+    const div = document.createElement('div');
+    div.className = 'gap-item';
+    div.textContent = c;
+    caveatsEl.appendChild(div);
+  });
+  const steps = firstPresent(qdata.recommended_next_steps, qdata.next_drills, qdata.agent?.recommended_next_steps, []);
+  if (steps.length) {
+    const h = document.createElement('div');
+    h.className = 'section-heading';
+    h.textContent = 'Next Drills';
+    caveatsEl.appendChild(h);
+    steps.forEach(s => {
+      const div = document.createElement('div');
+      div.className = 'next-step';
+      div.innerHTML = '<div class="step-title">' + esc(firstPresent(s.title, s.summary, 'Next drill')) + '</div>'
+        + '<div class="step-why">' + esc(firstPresent(s.why, s.reason, '')) + '</div>'
+        + (s.command ? '<code>' + esc(s.command) + '</code>' : '');
+      caveatsEl.appendChild(div);
+    });
+  }
+  if (caveatsEl.children.length) document.getElementById('deep-caveats-section').classList.remove('hidden');
+})();
+</script>
+
 <!-- Agent Findings -->
 <div class="findings-card" id="agent-section">
   <h2 id="agent-title">Key Findings</h2>
@@ -469,6 +722,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('agent-section').classList.add('hidden'); return; }
   const agent = qdata.agent || {};
   const takeaways = getTakeaways(qdata);
   if (!agent.top_findings?.length && !takeaways.length) { document.getElementById('agent-section').classList.add('hidden'); return; }
@@ -548,6 +802,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('eval-section').classList.add('hidden'); return; }
   const children = window._evalChildren;
   if (!children || !children.length) { document.getElementById('eval-section').classList.add('hidden'); return; }
 
@@ -619,6 +874,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('waterfall-section').classList.add('hidden'); return; }
   const root = window._evalRoot;
   if (!root || !root.contributions || !root.contributions.length) {
     document.getElementById('waterfall-section').classList.add('hidden'); return;
@@ -682,6 +938,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('trend-section').classList.add('hidden'); return; }
   const evals = qdata.trend?.evaluations || [];
   const periods = qdata.trend?.periods || [];
 
@@ -773,6 +1030,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('rca-section').classList.add('hidden'); return; }
   const contributors = getRootContributors(qdata);
   if (!contributors.length) { document.getElementById('rca-section').classList.add('hidden'); return; }
 
@@ -838,6 +1096,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('confidence-section').classList.add('hidden'); return; }
   const rc = qdata.root_cause || {};
   const conclusion = getConfidenceConclusion(qdata);
   const score = conclusion.confidence_score;
@@ -876,6 +1135,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
+  if (isDeepDiveBundle(qdata)) { document.getElementById('compare-section').classList.add('hidden'); return; }
   const t1 = qdata.tree1;
   const t2 = qdata.tree2;
   if (!t1 || !t2) { document.getElementById('compare-section').classList.add('hidden'); return; }
@@ -934,7 +1194,7 @@ function getTakeaways(data) {
 </div>
 <script>
 (function() {
-  const sections = ['eval-section', 'waterfall-section', 'trend-section', 'rca-section', 'confidence-section', 'compare-section'];
+  const sections = ['deep-dive-section', 'eval-section', 'waterfall-section', 'trend-section', 'rca-section', 'confidence-section', 'compare-section'];
   const anyVisible = sections.some(id => !document.getElementById(id).classList.contains('hidden'));
   if (!anyVisible) document.getElementById('no-data-section').classList.remove('hidden');
 })();

--- a/tests/test_renderer_contract.sh
+++ b/tests/test_renderer_contract.sh
@@ -26,6 +26,10 @@ assert_contains "$ROOT/plugins/qluent/commands/investigate.md" \
   '--json-output | tee /tmp/qluent-viz-data.json'
 assert_not_contains "$ROOT/plugins/qluent/commands/investigate.md" \
   '--json-output 2>&1 | tee /tmp/qluent-viz-data.json'
+assert_contains "$ROOT/plugins/qluent/commands/deep-dive.md" \
+  '--json-output --period "<period>" | tee /tmp/qluent-deep-dive-bundle.json'
+assert_not_contains "$ROOT/plugins/qluent/commands/deep-dive.md" \
+  '--json-output --period "<period>" 2>&1 | tee /tmp/qluent-deep-dive-bundle.json'
 
 assert_contains "$ROOT/plugins/qluent/agents/qluent-analyst.md" \
   '--json-output | tee /tmp/qluent-viz-data.json'
@@ -43,6 +47,14 @@ assert_not_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
 # Guard against NaN% when a contributor has no delta_share (e.g. takeaway fallback)
 assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
   'c.delta_share != null'
+assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'function isDeepDiveBundle(data)'
+assert_contains "$ROOT/plugins/qluent/templates/render-charts.html" \
+  'Cross-tree Root Movement'
+assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
+  "outcomeShape: 'driver_concentration' | 'mix_shift' | 'elasticity_tradeoff' | 'data_quality_blocker' | 'cross_tree_bundle' | string"
+assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
+  'cross_tree_hotspot_grid'
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
@@ -136,6 +148,80 @@ JSON
 "$ROOT/plugins/qluent/scripts/render-charts.sh" "$takeaway_only_json" "$takeaway_html" >/dev/null
 assert_contains "$takeaway_html" '"title": "Gross Revenue"'
 
+deep_dive_json="$tmpdir/deep_dive.json"
+deep_dive_html="$tmpdir/deep_dive.html"
+
+cat > "$deep_dive_json" <<'JSON'
+{
+  "outcomeShape": "cross_tree_bundle",
+  "title": "Q1 vs Q4 Deep Dive",
+  "period_label": "Q1 2026 vs Q4 2025",
+  "trees": [
+    {
+      "tree_id": "revenue",
+      "tree_label": "Revenue",
+      "status": "blocked",
+      "evaluation": {
+        "root": {
+          "id": "net_revenue",
+          "label": "Net Revenue",
+          "current_value": 39090016.17,
+          "comparison_value": 0,
+          "delta_value": 39090016.17,
+          "delta_ratio": null,
+          "contributions": [
+            {"node_id": "gross_revenue", "label": "Gross Revenue", "delta_value": 39090016.17, "delta_share": 1}
+          ]
+        }
+      },
+      "agent": {
+        "gaps": ["Revenue comparison is missing or zero"]
+      }
+    },
+    {
+      "tree_id": "funnel",
+      "tree_label": "Conversion Funnel",
+      "evaluation": {
+        "root": {
+          "id": "conversion_rate",
+          "label": "Conversion Rate",
+          "current_value": 0.034,
+          "comparison_value": 0.041,
+          "delta_value": -0.007,
+          "delta_ratio": -0.1707
+        }
+      },
+      "root_cause": {
+        "conclusion": {
+          "takeaways": [
+            {"kind": "driver", "title": "Checkout conversion", "summary": "Checkout conversion drove the decline", "delta_value": -0.006, "share_of_change": 0.86}
+          ]
+        },
+        "findings": [
+          {
+            "segment_findings": [
+              {"dimension": "channel", "segment": "paid_search", "delta_value": -0.004, "delta_share": 0.57, "direction": "down"}
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "cross_tree_overlap": ["paid_search appears in funnel and growth declines"],
+  "caveats": ["Operations tree was sparse"],
+  "recommended_next_steps": [
+    {"title": "Drill into paid search", "why": "Largest repeated hotspot", "command": "qluent rca analyze funnel --period \"Q1 2026\" --segment-by channel --json-output"}
+  ]
+}
+JSON
+
+"$ROOT/plugins/qluent/scripts/render-charts.sh" "$deep_dive_json" "$deep_dive_html" >/dev/null
+assert_contains "$deep_dive_html" '"outcomeShape": "cross_tree_bundle"'
+assert_contains "$deep_dive_html" 'Cross-tree Root Movement'
+assert_contains "$deep_dive_html" 'Segment Hotspots'
+assert_contains "$deep_dive_html" 'paid_search appears in funnel and growth declines'
+assert_contains "$deep_dive_html" 'Revenue comparison is missing or zero'
+
 cat > "$contaminated_json" <<'TEXT'
 [qluent] awaiting response... (30s)
 {"tree_id":"revenue"}
@@ -145,5 +231,7 @@ if "$ROOT/plugins/qluent/scripts/render-charts.sh" "$contaminated_json" "$tmpdir
   fail "render-charts.sh should reject contaminated non-JSON input"
 fi
 assert_contains "$tmpdir/render.err" "Input is not valid JSON"
+assert_contains "$tmpdir/render.err" "Diagnosis: expected JSON at line 1"
+assert_contains "$tmpdir/render.err" "qluent trees deep-dive --json-output --period"
 
 echo "renderer contract tests passed"

--- a/tests/test_session_paths.sh
+++ b/tests/test_session_paths.sh
@@ -65,6 +65,7 @@ assert_contains "$SKILL" '/tmp/qluent-tree-capabilities.json'
 
 # 2. Allowlist enforcement.
 check_path '/tmp/qluent-viz-data.json' \
+  'plugins/qluent/CLAUDE.md' \
   'plugins/qluent/agents/qluent-analyst.md' \
   'plugins/qluent/commands/investigate.md' \
   'plugins/qluent/commands/visualize.md' \
@@ -75,9 +76,13 @@ check_path '/tmp/qluent-viz-data.json' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-deep-dive-bundle.json' \
+  'plugins/qluent/CLAUDE.md' \
   'plugins/qluent/commands/deep-dive.md' \
+  'plugins/qluent/commands/visualize.md' \
   'plugins/qluent/scripts/post-bash.sh' \
+  'plugins/qluent/scripts/render-charts.sh' \
   'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_renderer_contract.sh' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-tree-capabilities.json' \


### PR DESCRIPTION
## Summary

Fixes the plugin-side work for #55 by routing deep-dive visualization through a deterministic bundle renderer instead of hand-written HTML.

## What changed

- Capture deep-dive JSON from stdout only so stderr/progress text cannot contaminate /tmp/qluent-deep-dive-bundle.json.
- Extend /qluent:visualize guidance with cross_tree_bundle and cross-tree section types.
- Add deep-dive bundle rendering to render-charts.html for root movement, hotspots, overlap, drivers, caveats, and next drills.
- Improve renderer validation errors with a diagnosis, clean re-run command, and contract pointer.
- Add renderer contract coverage for deep-dive bundles and contaminated input.

## Validation

- bash tests/test_renderer_contract.sh
- bash tests/test_command_surface.sh
- bash tests/test_protocol_locality.sh