### PR TITLE
feat: render insight-driven HTML dashboard from /qluent:deep-dive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,5 @@ jobs:
         run: bash tests/test_session_paths.sh
       - name: Run fallback algorithm test
         run: bash tests/test_fallback_algorithm.sh
+      - name: Run deep-dive HTML contract test
+        run: bash tests/test_deep_dive_html_contract.sh

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -1,7 +1,7 @@
 ---
 description: Run a consented cross-tree deep dive and synthesize one executive narrative across all metric trees
 argument-hint: "[period | --period 'last week' | YYYY-MM-DD:YYYY-MM-DD] [--yes] [--brief]"
-allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read, Write
+allowed-tools: Bash(which qluent), Bash(qluent *), Bash(date *), AskUserQuestion, Read, Write
 ---
 
 # Deep dive across metric trees

--- a/plugins/qluent/commands/deep-dive.md
+++ b/plugins/qluent/commands/deep-dive.md
@@ -1,7 +1,7 @@
 ---
 description: Run a consented cross-tree deep dive and synthesize one executive narrative across all metric trees
 argument-hint: "[period | --period 'last week' | YYYY-MM-DD:YYYY-MM-DD] [--yes] [--brief]"
-allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read
+allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read, Write
 ---
 
 # Deep dive across metric trees
@@ -177,6 +177,63 @@ Rules for synthesis:
 - Keep concise. If `--brief` is present, use shorter bullets but still include
   all five headings.
 
+## Step 7: Render the insight-driven HTML dashboard
+
+After delivering the markdown narrative, produce a companion HTML dashboard from
+the same bundle. This is the primary visual artifact for `/qluent:deep-dive`:
+the layout reflects what the bundle says, not a fixed template.
+
+Read the dashboard design system before composing the HTML:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/dashboard-design/SKILL.md
+```
+
+Write the dashboard to a unique path so older runs do not collide:
+
+```
+/tmp/qluent-deep-dive-$(date +%Y%m%d-%H%M%S).html
+```
+
+Compose sections using the skill's insight-to-section mapping, biased toward the
+cross-tree shape of a deep-dive bundle. Drive every value, label, and chart
+series from the bundle JSON; do not invent figures or fill placeholders.
+
+Suggested cross-tree section order (include only those the bundle supports):
+
+1. **Hero** — insight-driven headline (e.g. "Restaurants collapsed, express
+   surged"), period, executive read, decisive metric in `<em>` colored per the
+   skill's color conventions.
+2. **KPI strip** — one card per tree with root metric label, current value,
+   comparison value, absolute and percentage movement. Color deltas with
+   `.up`/`.down`.
+3. **Cross-tree concentration** — hotspot grid for repeated segments across
+   trees, using stat blocks or a priority table from the skill.
+4. **Mechanism** — strongest supported mechanism (volume, AOV, mix, conversion,
+   ops quality) using mechanism decomposition or mix-effect components when the
+   bundle supports them.
+5. **Per-tree drill-down cards** — short cards for trees that materially moved,
+   each with its top driver and a Chart.js bar/line bound to bundle series.
+   Omit trees that did not move materially.
+6. **Insight callouts** — `.insight`, `.insight-warn`, or `.insight-bad`
+   callouts under the most important charts. These surface the takeaways from
+   the markdown Headline, Concentration, and Mechanism sections beside the data.
+7. **Caveats** — stat block or list mirroring the markdown Caveats section
+   (errored trees, low-confidence findings, sparse data, unsupported cuts).
+8. **Next-best drills** — priority table or list of the same copy-pasteable
+   commands as the markdown Next-best drills.
+
+Section titles must be insight statements, not generic labels. Only include
+sections backed by actual bundle data; omit a section rather than render an
+empty placeholder.
+
+After writing the file, surface the path so the user can open it locally:
+
+```
+Wrote insight-driven dashboard: /tmp/qluent-deep-dive-<timestamp>.html
+Open with `open <path>` (macOS) or `xdg-open <path>` (Linux).
+```
+
 ## Next-best drill command format
 
 Recommended next drills must be copy-pasteable and valid for this plugin/project.
@@ -206,3 +263,6 @@ order. Include why each drill is recommended in one sentence.
 - Per-tree errors and low-confidence findings must appear in Caveats.
 - Recommendations must be concrete `/qluent:investigate` slash commands or
   underlying `qluent` CLI subcommands — never paraphrased actions.
+- Always render an insight-driven HTML dashboard via the `dashboard-design`
+  skill alongside the markdown narrative. Section composition is data-driven,
+  not templated; only include sections the bundle supports.

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -1,5 +1,5 @@
 ---
-description: Shape the latest qluent analysis output into a UI RcaReportSpec, with gated HTML fallback
+description: Shape the latest qluent analysis output into a UI RcaReportSpec, with insight-driven HTML on request
 argument-hint: "[--file /path/to/json] [--simple] [--html]"
 allowed-tools: Bash(*), Read, Write, Glob
 ---
@@ -8,10 +8,10 @@ allowed-tools: Bash(*), Read, Write, Glob
 
 Shapes the most recent qluent analysis into an outcome-shaped `RcaReportSpec`
 for the Qluent UI. When deterministic RCA or elasticity output is available
-the report spec is the required primary artifact. Local HTML is a fallback
-only on `--simple`/`--html`, an explicit local/browser request, or when the
-UI contract cannot be consumed. Follow the `qluent-interpretation` skill for
-provenance and evidence labels.
+the report spec is the required primary artifact. Explicit local HTML/dashboard
+requests should produce an insight-driven dashboard from the analysis data.
+`--simple` remains the generic renderer fallback. Follow the
+`qluent-interpretation` skill for provenance and evidence labels.
 
 ## Step 0: Load the canonical interpretation protocol
 
@@ -67,11 +67,12 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/render-charts.sh" /tmp/qluent-viz-data.json 
 echo "Rendered Qluent report fallback: $out"
 ```
 
-**HTML fallback mode** (`--html`, explicit local/browser demo request, or unavailable UI
-contract only): Prefer `render-charts.sh` and a unique `/tmp/qluent-viz-<timestamp>.html`
-path. If custom HTML is unavoidable, drive it only from values present in the qluent JSON
-or explicit user-provided values. Do not invent, infer, or hardcode chart values from
-conversation context.
+**Insight-driven HTML mode** (`--html`, explicit dashboard/local/browser request, or
+unavailable UI contract): Compose custom HTML from the investigation data via the
+`dashboard-design` skill and write it to a unique `/tmp/qluent-viz-<timestamp>.html`
+path. This mode should be specific to the produced analysis, not the generic renderer
+template. Drive every value, label, chart series, caveat, and recommendation from the
+qluent JSON; do not invent, infer, or hardcode chart values from conversation context.
 
 ## Step 3: Build an outcome-shaped RcaReportSpec
 
@@ -163,15 +164,50 @@ named in the skill exactly when present.
 ## Step 4: HTML fallback for local demos
 
 Do not enter this step for normal deterministic RCA or elasticity visualization requests.
-HTML is a local fallback, not the synchronized report artifact.
+HTML is a local/dashboard artifact, not the synchronized report artifact.
 
-Read the JSON data and include only sections whose values map directly from qluent JSON.
-If a value needed for a chart cannot be mapped from the JSON, omit that section or state
-the missing deterministic field/query instead of inventing a placeholder chart.
+For `--html` or explicit dashboard/local/browser requests, first read the dashboard
+design system:
 
-For simple local output, run `render-charts.sh`. If custom HTML is explicitly requested
-and unavoidable, reference the `dashboard-design` skill for styling and keep every chart
-bound to deterministic fields from `/tmp/qluent-viz-data.json` or `--file <path>`.
+```
+${CLAUDE_PLUGIN_ROOT}/skills/dashboard-design/SKILL.md
+```
+
+Then write a unique output path:
+
+```bash
+out="/tmp/qluent-viz-$(date +%Y%m%d-%H%M%S).html"
+```
+
+Compose sections using the skill's insight-to-section mapping and the chosen
+`outcomeShape`. Include only sections whose values map directly from qluent JSON. If a
+value needed for a chart cannot be mapped from the JSON, omit that section or state the
+missing deterministic field/query instead of inventing a placeholder chart.
+
+Suggested single-tree section order (include only those the investigation supports):
+
+1. **Hero** — outcome-specific headline, exact current/comparison windows, root metric
+   movement, and the strongest supported read.
+2. **Root movement KPI strip** — current value, comparison value, absolute movement,
+   percentage movement, confidence, and evidence coverage when returned.
+3. **Driver decomposition** — Shapley/RCA contributors or returned takeaways, charted
+   only from deterministic contribution fields.
+4. **Material segment scan** — segment findings, mix shifts, or hotspot bars/tables
+   when `root_cause.findings[].segment_findings` or `mix_shift` exists.
+5. **Mechanism or elasticity** — mechanism takeaways, lever sensitivity, scenario
+   impact, and guardrails when the bundle includes them.
+6. **Insight callouts** — `.insight`, `.insight-warn`, or `.insight-bad` annotations
+   next to the charts they explain.
+7. **Caveats and next drills** — returned gaps, low-confidence notes, unsupported cuts,
+   and copy-pasteable recommended commands.
+
+For `--simple`, run `render-charts.sh`; this is the deliberately generic fallback:
+
+```bash
+out="/tmp/qluent-viz-$(date +%Y%m%d-%H%M%S).html"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/render-charts.sh" /tmp/qluent-viz-data.json "$out"
+echo "Rendered Qluent report fallback: $out"
+```
 
 ## Step 5: Open fallback HTML in browser
 
@@ -190,8 +226,9 @@ xdg-open "$out"
   elasticity output is available.
 - Do not hand-roll report HTML when the UI contract can be used.
 - Use unique fallback HTML output paths; do not silently reuse stale dashboards.
-- Use the `dashboard-design` skill for HTML fallback styling — do not invent
-  new styles.
+- Use the `dashboard-design` skill for explicit HTML/dashboard output so the
+  visualization follows the produced analysis, not a fixed template.
+- Use `render-charts.sh` only for `--simple` generic fallback output.
 - Section titles are insight statements, not generic labels.
 - Only include sections backed by actual data; omit the section or state the
   missing deterministic field if values cannot be mapped from the JSON.

--- a/tests/test_deep_dive_html_contract.sh
+++ b/tests/test_deep_dive_html_contract.sh
@@ -33,9 +33,10 @@ assert_not_contains() {
 # 1. The dashboard-design skill referenced by deep-dive.md must actually exist.
 [[ -f "$SKILL" ]] || fail "missing skill referenced by deep-dive.md: $SKILL"
 
-# 2. deep-dive.md frontmatter must allow Write so the model can save the HTML.
+# 2. deep-dive.md frontmatter must allow Write so the model can save the HTML,
+#    and date so the timestamped output path can be resolved.
 assert_contains "$DEEP_DIVE" \
-  'allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read, Write'
+  'allowed-tools: Bash(which qluent), Bash(qluent *), Bash(date *), AskUserQuestion, Read, Write'
 
 # 3. deep-dive.md must include the insight-driven HTML rendering step and link
 #    it to the dashboard-design skill.

--- a/tests/test_deep_dive_html_contract.sh
+++ b/tests/test_deep_dive_html_contract.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Locks in the contract that /qluent:deep-dive renders an insight-driven HTML
+# dashboard via the dashboard-design skill alongside the markdown narrative.
+# This test guards the prompt structure — not the rendered HTML, which Claude
+# composes at runtime from the deterministic bundle.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DEEP_DIVE="$ROOT/plugins/qluent/commands/deep-dive.md"
+SKILL="$ROOT/plugins/qluent/skills/dashboard-design/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file should contain: $needle"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file should not contain: $needle"
+  fi
+}
+
+# 1. The dashboard-design skill referenced by deep-dive.md must actually exist.
+[[ -f "$SKILL" ]] || fail "missing skill referenced by deep-dive.md: $SKILL"
+
+# 2. deep-dive.md frontmatter must allow Write so the model can save the HTML.
+assert_contains "$DEEP_DIVE" \
+  'allowed-tools: Bash(which qluent), Bash(qluent *), AskUserQuestion, Read, Write'
+
+# 3. deep-dive.md must include the insight-driven HTML rendering step and link
+#    it to the dashboard-design skill.
+assert_contains "$DEEP_DIVE" '## Step 7: Render the insight-driven HTML dashboard'
+assert_contains "$DEEP_DIVE" \
+  '${CLAUDE_PLUGIN_ROOT}/skills/dashboard-design/SKILL.md'
+
+# 4. The HTML output must use a unique timestamped path so older runs do not
+#    collide. Mirrors the /tmp/qluent-viz-<timestamp>.html convention.
+assert_contains "$DEEP_DIVE" '/tmp/qluent-deep-dive-$(date +%Y%m%d-%H%M%S).html'
+
+# 5. The "insight takeaways" surface — the user-visible feature being restored
+#    from the Apr 10 dashboard — must be present in the prompt.
+assert_contains "$DEEP_DIVE" 'Insight callouts'
+assert_contains "$DEEP_DIVE" '.insight-warn'
+assert_contains "$DEEP_DIVE" '.insight-bad'
+
+# 6. Section composition must be data-driven, not templated.
+assert_contains "$DEEP_DIVE" 'insight-to-section mapping'
+assert_contains "$DEEP_DIVE" 'sections backed by actual bundle data'
+assert_contains "$DEEP_DIVE" 'omit a section rather than render an'
+
+# 7. The Rules section must enforce the HTML rendering rather than leaving it
+#    optional, so the markdown narrative cannot ship without the dashboard.
+assert_contains "$DEEP_DIVE" \
+  'Always render an insight-driven HTML dashboard via the `dashboard-design`'
+
+# 8. The dashboard-design skill must define the components deep-dive.md leans
+#    on. If any of these are renamed, deep-dive.md needs to follow.
+assert_contains "$SKILL" '### Hero'
+assert_contains "$SKILL" '### KPI Strip'
+assert_contains "$SKILL" '### Insight Callout'
+assert_contains "$SKILL" '## Insight-to-Section Mapping'
+
+# 9. Deep-dive must not regress to the static-template path that visualize uses
+#    as its --simple fallback. That template lives in render-charts.html and is
+#    reachable from /qluent:visualize, not from /qluent:deep-dive.
+assert_not_contains "$DEEP_DIVE" 'render-charts.sh'
+assert_not_contains "$DEEP_DIVE" 'render-charts.html'
+
+echo "deep-dive HTML contract tests passed"

--- a/tests/test_renderer_contract.sh
+++ b/tests/test_renderer_contract.sh
@@ -55,6 +55,14 @@ assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
   "outcomeShape: 'driver_concentration' | 'mix_shift' | 'elasticity_tradeoff' | 'data_quality_blocker' | 'cross_tree_bundle' | string"
 assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
   'cross_tree_hotspot_grid'
+assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
+  '**Insight-driven HTML mode**'
+assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
+  '${CLAUDE_PLUGIN_ROOT}/skills/dashboard-design/SKILL.md'
+assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
+  'Suggested single-tree section order'
+assert_contains "$ROOT/plugins/qluent/commands/visualize.md" \
+  'Use `render-charts.sh` only for `--simple` generic fallback output.'
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT


### PR DESCRIPTION
## Summary

- `/qluent:deep-dive` now writes a companion HTML dashboard alongside the markdown narrative, composed via the `dashboard-design` skill's insight-to-section mapping (Apr 10 `045ba86` style) instead of the fixed-template `render-charts.html` toggle path.
- Sections are chosen from the bundle (hero, KPI strip, cross-tree concentration, mechanism, per-tree drill-downs, insight callouts, caveats, next-best drills); only sections backed by bundle data are rendered.
- Deterministic CLI bundle (`qluent trees deep-dive --json-output ... | tee /tmp/qluent-deep-dive-bundle.json`) and the markdown narrative shape are unchanged. The static `render-charts.html` template is preserved as the `/qluent:visualize --simple` fallback.

## Why

The current deep-dive HTML is deterministic but feels less fit-for-purpose: every dive renders the same sections regardless of what moved. The Apr 10 `dashboard-design` skill picks sections from the data and surfaces takeaways inline as insight callouts — more dynamic without sacrificing the deterministic JSON underneath.

## Changes

- `plugins/qluent/commands/deep-dive.md`
  - Added `Write` to `allowed-tools`.
  - Added **Step 7: Render the insight-driven HTML dashboard** — reads `${CLAUDE_PLUGIN_ROOT}/skills/dashboard-design/SKILL.md`, writes `/tmp/qluent-deep-dive-<timestamp>.html`, composes data-driven sections with insight callouts.
  - Added Rules bullet: HTML rendering is now mandatory alongside the markdown narrative; section composition is data-driven, not templated.

## Test plan

- [x] `tests/test_command_surface.sh`
- [x] `tests/test_renderer_contract.sh` (still asserts the deterministic `tee` line + `isDeepDiveBundle` template helpers)
- [x] `tests/test_session_paths.sh`
- [x] `tests/test_doc_seams.sh`
- [x] `tests/test_protocol_locality.sh`
- [ ] Manual: run `/qluent:deep-dive last week` against a real CLI, confirm both the markdown narrative and `/tmp/qluent-deep-dive-<timestamp>.html` are produced and the HTML sections vary with bundle content.

https://claude.ai/code/session_01Xtgth9FvTt8y9S8gmCTyfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtgth9FvTt8y9S8gmCTyfQ)_