### PR TITLE
release: bump plugin to 0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "author": {
         "name": "Qluent"
       },

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qluent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"


### PR DESCRIPTION
## Summary

- Bumps the plugin from 0.3.2 → 0.3.3 across all three manifests (`plugins/qluent/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the nested `plugins[].version` entry).
- Releases the insight-driven HTML dashboard work that landed in #58 (deep-dive Step 7 + visualize HTML mode) so the CLI/marketplace can pick up the new version.

No code changes — manifest only. Generated via `node scripts/bump-version.mjs 0.3.3`; CI's `node scripts/bump-version.mjs --check` will verify the manifests stay in sync.

## Test plan

- [x] `node scripts/bump-version.mjs --check 0.3.3` passes
- [x] All seven test suites pass locally (`tests/test_*.sh`)
- [ ] CI green on this PR

https://claude.ai/code/session_01Xtgth9FvTt8y9S8gmCTyfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtgth9FvTt8y9S8gmCTyfQ)_