### PR TITLE
Harden /qluent:query pipelines: heredoc question passing + private tmp file

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "author": {
         "name": "Qluent"
       },

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qluent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -46,11 +46,20 @@ explicit raw-data ask), run:
 
 ```bash
 set -o pipefail
-qluent query "<question>" --json-output | tee /tmp/qluent-query-result.json
+umask 077
+question=$(command cat <<'QLUENT_QUERY'
+<question>
+QLUENT_QUERY
+)
+rm -f /tmp/qluent-query-result.json
+qluent query "$question" --json-output | tee /tmp/qluent-query-result.json
 ```
 
-(`pipefail` keeps qluent's exit status visible through the tee; without it a
-failed run looks successful and leaves an invalid saved file.)
+(The quoted heredoc keeps user-controlled question text inert instead of
+letting `$(...)`/backticks/quotes expand; `pipefail` keeps qluent's exit
+status visible through the tee; `umask 077` + `rm -f` keep the saved file
+private and clobber stale files. Same pattern for clarification answers —
+see `/qluent:query`.)
 
 Check `status`: on `clarification_needed`, present the options and re-run
 with `--thread <thread_id>` and the answer; on `ok`, present the result with

--- a/plugins/qluent/commands/query.md
+++ b/plugins/qluent/commands/query.md
@@ -74,12 +74,27 @@ Run with a long Bash timeout (600000 ms) and save the JSON for this session:
 
 ```bash
 set -o pipefail
-qluent query "<question>" --json-output | tee /tmp/qluent-query-result.json
+umask 077
+question=$(command cat <<'QLUENT_QUERY'
+<question>
+QLUENT_QUERY
+)
+rm -f /tmp/qluent-query-result.json
+qluent query "$question" --json-output | tee /tmp/qluent-query-result.json
 ```
 
-`pipefail` preserves qluent's exit status through the tee — without it a
-failed CLI run exits 0 (tee's status) and leaves an empty or invalid saved
-file that downstream steps would silently consume.
+This shape is load-bearing, not style:
+
+- The quoted heredoc keeps the user-controlled question text inert — pasted
+  directly inside quotes, `$(...)`, backticks, or embedded quotes in the
+  question would execute or break the command. `command cat` bypasses any
+  shell alias on `cat`.
+- `pipefail` preserves qluent's exit status through the tee — without it a
+  failed CLI run exits 0 (tee's status) and leaves an invalid saved file that
+  downstream steps would silently consume.
+- `umask 077` + `rm -f` recreate the saved file private to the current user
+  each round (results can contain warehouse rows and SQL) and clobber any
+  stale file or symlink already at the fixed path.
 
 If the user passed `--thread <id>` (or this is a follow-up / clarification
 answer), add `--thread <thread_id>`. Keep stderr out of the saved file:
@@ -102,8 +117,18 @@ present the clarification `message` and its `options` to the user with
 
 ```bash
 set -o pipefail
-qluent query "<the user's answer>" --thread <thread_id> --json-output | tee /tmp/qluent-query-result.json
+umask 077
+answer=$(command cat <<'QLUENT_ANSWER'
+<the user's answer>
+QLUENT_ANSWER
+)
+rm -f /tmp/qluent-query-result.json
+qluent query "$answer" --thread <thread_id> --json-output | tee /tmp/qluent-query-result.json
 ```
+
+(The answer text is user-controlled too — same quoted-heredoc rule as Step 3.
+The `<thread_id>` comes from the previous qluent response, so plain
+substitution is fine there.)
 
 Cap the loop at 3 rounds; after that, report the open ambiguity to the user
 instead of looping further.

--- a/tests/test_query_contract.sh
+++ b/tests/test_query_contract.sh
@@ -70,6 +70,18 @@ assert_not_contains "$QUERY_CMD" '2>&1 | tee'
 # status, so a failed CLI run looks successful and leaves an invalid saved file.
 assert_contains "$QUERY_CMD" 'set -o pipefail'
 assert_contains "$ANALYST" 'set -o pipefail'
+# Injection-safety rule: user-controlled question/answer text must pass through
+# a quoted heredoc, never be pasted directly into the command line.
+assert_contains "$QUERY_CMD" "<<'QLUENT_QUERY'"
+assert_contains "$QUERY_CMD" "<<'QLUENT_ANSWER'"
+assert_contains "$QUERY_CMD" 'qluent query "$question"'
+assert_not_contains "$QUERY_CMD" 'qluent query "<question>"'
+assert_contains "$ANALYST" "<<'QLUENT_QUERY'"
+assert_not_contains "$ANALYST" 'qluent query "<question>"'
+# Private-file rule: recreate the saved result 0600 and clobber stale files.
+assert_contains "$QUERY_CMD" 'umask 077'
+assert_contains "$QUERY_CMD" 'rm -f /tmp/qluent-query-result.json'
+assert_contains "$ANALYST" 'umask 077'
 
 # 2. The skill owns the canonical routing rule and session-path declaration.
 assert_contains "$SKILL" '## Ad-hoc query routing'


### PR DESCRIPTION
Follow-up to #63 (review findings that landed after the merge).

1. **Shell injection**: the question and clarification-answer text is fully user-controlled, and the command allowlists `Bash(qluent *)` — text containing `$(...)`, backticks, or embedded quotes pasted directly into the command line could execute before qluent runs. The pipelines in `query.md` and `qluent-analyst.md` now pass the text through a quoted heredoc into a variable and expand only `"$question"`. `command cat` bypasses shell aliases on `cat`.

2. **Sensitive data at a predictable /tmp path**: query results can contain warehouse rows and SQL. The canonical session path is kept (it is pinned by the skill, hook, visualize, and `test_session_paths.sh`), but recreated privately each round with `umask 077` + `rm -f` — the file lands 0600 and any stale file or symlink at the path is clobbered.

Both rules are pinned in `test_query_contract.sh`. Verified end-to-end in a real shell: an injection payload stays literal data, the saved file is `-rw-------`, and a CLI failure still propagates through the tee (pipefail, from #63).

Version bumped to 0.4.1 so the marketplace cache picks up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)