### PR TITLE
Auto-approve qluent CLI commands so users aren't prompted per query

### DIFF
--- a/plugins/qluent/hooks/hooks.json
+++ b/plugins/qluent/hooks/hooks.json
@@ -1,6 +1,19 @@
 {
-  "description": "Qluent hooks — session context injection and post-command guidance.",
+  "description": "Qluent hooks — session context injection, auto-approval of qluent CLI commands, and post-command guidance.",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(qluent *)",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-bash.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/plugins/qluent/scripts/pre-bash.sh
+++ b/plugins/qluent/scripts/pre-bash.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: auto-approves `qluent` CLI commands so the plugin's
+# skills and slash-commands never prompt for permission on each query.
+#
+# Safety: this emits an "allow" permission decision only for a *single* qluent
+# invocation. A PreToolUse allow approves the entire Bash command, so anything
+# that chains, pipes, redirects, or substitutes (`;`, `|`, `&`, `<`, `>`, `` ` ``,
+# `$(...)`, newlines) is deliberately NOT auto-approved — those fall through to
+# the normal permission prompt, exactly like the `Bash(qluent:*)` allow rule.
+# The match lives in this script (not just the hook's `if` filter) so it stays
+# safe on Claude Code versions that predate `if`.
+
+set -euo pipefail
+
+jq_bin=$(command -v jq || true)
+[ -n "$jq_bin" ] || exit 0
+
+# Tool input arrives via the TOOL_INPUT env var (harness convention used by the
+# sibling hooks); fall back to stdin for robustness.
+payload="${TOOL_INPUT:-}"
+if [ -z "$payload" ]; then
+  payload=$(cat 2>/dev/null || true)
+fi
+[ -n "$payload" ] || exit 0
+
+command=$(printf '%s' "$payload" | "$jq_bin" -r '.command // .tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$command" ] || exit 0
+
+# Trim leading whitespace.
+command="${command#"${command%%[![:space:]]*}"}"
+
+# Fall through to the normal prompt if the command chains / pipes / redirects /
+# substitutes — never blanket-approve a piggy-backed command.
+if [[ "$command" == *';'* || "$command" == *'|'* || "$command" == *'&'* \
+   || "$command" == *'<'* || "$command" == *'>'* || "$command" == *'`'* \
+   || "$command" == *'$('* || "$command" == *$'\n'* ]]; then
+  exit 0
+fi
+
+# Auto-approve only when the command is a bare qluent invocation.
+case "$command" in
+  qluent | "qluent "*)
+    printf '%s\n' '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow", "permissionDecisionReason": "qluent CLI command auto-approved by the qluent plugin"}}'
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Problem

When a plugin skill or slash-command runs a `qluent ...` Bash command in the main thread, the user gets a permission prompt **every single time** — because each command's text differs (different question, different window), Claude Code can't match it to a prior approval. This is friction on the plugin's core path.

Subagents (`qluent-analyst`, `rca-validator`, …) already avoid this because their frontmatter restricts tools to `Bash(qluent *)`, which grants permission within the agent. The gap is the main thread + skills.

## Why a hook (and not a permission rule)

Plugins **cannot** ship `permissions.allow` rules — `plugin.json` only supports `agent` and `subagentStatusLine`. The supported mechanism is a hook, so this adds a `PreToolUse` hook that emits an `allow` permission decision for qluent commands. It activates only when the plugin is installed, and disappears on uninstall.

## Safety

A `PreToolUse` allow approves the **entire** Bash command, so a naive prefix check would blanket-approve `qluent query "x"; rm -rf ~`. To prevent that, `scripts/pre-bash.sh`:

- auto-approves **only a single, bare `qluent …` invocation**, and
- **falls through to the normal permission prompt** whenever the command contains shell chaining / piping / redirection / substitution (`;` `|` `&` `<` `>` `` ` `` `$(` newline).

This matches the safety of a `Bash(qluent:*)` allow rule (Claude Code splits compound commands and re-prompts on the non-qluent parts). The match lives **in the script**, not just the hook's `if:` filter, so it stays safe on Claude Code versions that predate `if` (where `if` is ignored and an unconditional allow would otherwise approve all Bash).

## Test

`scripts/pre-bash.sh` verified against representative inputs:

| Command | Result |
|---|---|
| `qluent query "why did revenue drop"` | ✅ allow |
| `qluent investigate revenue last month` | ✅ allow |
| `qluent trees list --json-output` | ✅ allow |
| `qluent query "x" \| tee /tmp/r.json` | prompt (fall-through) |
| `qluent query "x"; rm -rf /tmp/foo` | prompt (fall-through) |
| `qluent query "revenue > target"` | prompt (fall-through) |
| `ls -la` | prompt (fall-through) |
| `echo qluent` | prompt (fall-through) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)