### PR TITLE
chore: bump plugin to 0.4.2 (ship the qluent auto-approval hook)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Deterministic KPI analysis with metric trees, trend analysis, and root cause analysis.",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {
       "name": "qluent",
       "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "author": {
         "name": "Qluent"
       },

--- a/plugins/qluent/.claude-plugin/plugin.json
+++ b/plugins/qluent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qluent",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Analyze business metrics, investigate KPI movements, and run deterministic root cause analysis from Claude Code.",
   "author": {
     "name": "Qluent"


### PR DESCRIPTION
Follow-up to #65. That PR merged the `PreToolUse` auto-approval hook, but at version `0.4.1`.

The marketplace cache key includes the version string, so clients already on `0.4.1` keep their cached copy and never receive the new hook until the version moves. This bumps all three manifest fields to `0.4.2` (via `scripts/bump-version.mjs`) so the hook actually ships on the next `/plugin marketplace update qluent-metric-trees`.

No functional code change — version manifests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)