### PR TITLE
feat: composed-plan authoring skill + plan-first /qluent:query routing

### DIFF
--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -31,7 +31,7 @@ anything.
 - **Cross-tree deep dive** — one consented executive narrative across all trees
 - **Segment drill-down** — find which segments concentrate a movement
 - **Sensitivity / lever impact** — elasticity coefficients and scenario estimates
-- **Ad-hoc data questions** — natural language to SQL for row-level, entity, or arbitrary questions no tree covers
+- **Ad-hoc data questions** — composed QueryPlans (deterministic, catalog-checked) for aggregations and cuts the query catalog covers, falling back to natural-language-to-SQL for row-level, entity, or arbitrary questions neither trees nor the catalog cover
 
 **Match suggestions to tree structure:** trees with children → RCA; trees with
 dimensions → segment drill-down; multiple trees → comparison; any tree → trend

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -4,6 +4,7 @@ description: Proactively use when the user asks about business metrics, KPI move
 tools: Bash
 skills:
   - qluent-interpretation
+  - compose-authoring
 ---
 
 You are an autonomous KPI analyst that uses the qluent CLI to answer business
@@ -38,11 +39,40 @@ rules in the `qluent-interpretation` skill first. Continue from a matching
 cached or fetched saved run when available instead of starting by rerunning the
 investigation.
 
-### Step 0: Route tree vs ad-hoc query
+### Step 0: Route tree vs composed plan vs NL query
 
 Apply the skill's ad-hoc query routing rule first. When the question routes
-to an ad-hoc query (row/entity level, no tree coverage, SQL-shaped, or an
-explicit raw-data ask), run:
+away from trees (row/entity level, no tree coverage, SQL-shaped, or an explicit
+raw-data ask), prefer the composed-plan path from the `compose-authoring` skill.
+
+Probe `qluent plan --help`. When supported, reuse
+`/tmp/qluent-catalog.json` if present or fetch it with:
+
+```bash
+umask 077
+[ -s /tmp/qluent-catalog.json ] || qluent catalog --json-output > /tmp/qluent-catalog.json
+```
+
+If the catalog covers every required base, metric, dimension and filter,
+author `/tmp/qluent-plan.json` with a quoted heredoc, then run:
+
+```bash
+set -o pipefail
+umask 077
+rm -f /tmp/qluent-plan-result.json
+qluent plan --file /tmp/qluent-plan.json --json-output | tee /tmp/qluent-plan-result.json >/dev/null
+```
+
+Inspect `status`. On `plan_invalid`, repair the plan from the returned
+instruction and retry at most three rounds. On `ok`, answer from the rows,
+show the compiled SQL, respect `grain` and `metrics[*].summable`, label the
+provenance "composed query (deterministic)", then stop — the tree workflow
+below does not apply.
+
+Fall back to the NL path only when `qluent plan --help` is unavailable, the
+catalog lacks essential vocabulary, the node algebra cannot express the
+question, or plan execution returns a hard error. Say which vocabulary or
+capability forced the fallback. Run:
 
 ```bash
 set -o pipefail

--- a/plugins/qluent/commands/query.md
+++ b/plugins/qluent/commands/query.md
@@ -1,19 +1,25 @@
 ---
-description: Ask an ad-hoc natural-language data question answered via SQL over the warehouse (row-level, entity lookups, cuts outside the metric trees)
+description: Ask an ad-hoc data question — answered by a deterministic composed QueryPlan when the query catalog covers it, else via LLM-generated SQL over the warehouse (row-level, entity lookups, cuts outside the metric trees)
 argument-hint: "<question> [--thread <id>]"
-allowed-tools: Bash(which qluent), Bash(qluent *), Bash(jq *), AskUserQuestion, Read
+allowed-tools: Bash(which qluent), Bash(qluent *), Bash(jq *), AskUserQuestion, Read, Write
 ---
 
-# Ad-hoc natural-language query
+# Ad-hoc query (composed plan first, NL fallback)
 
 Use when the user asks a data question the metric trees cannot answer:
 row-level or entity lookups, arbitrary aggregations or filters, or explicit
-raw-data requests. The question is answered by the qluent backend's LLM query
-workflow (natural language -> generated SQL -> warehouse execution), so the
-result is not deterministic tree evidence — follow the `qluent-interpretation`
-skill's ad-hoc query routing and provenance rules throughout.
+raw-data requests. Two engines answer these, tried in order:
 
-## Step 0: Load the canonical interpretation protocol
+1. **Composed plan** (`qluent plan`) — you author a typed QueryPlan against
+   the project's query catalog; the backend compiles it deterministically.
+   Preferred whenever the catalog covers the question.
+2. **NL query** (`qluent query`) — the backend's LLM workflow (natural
+   language -> generated SQL -> execution); non-deterministic. The fallback.
+
+Follow the `qluent-interpretation` skill's routing and provenance rules
+throughout.
+
+## Step 0: Load the canonical protocols
 
 Before anything else, `Read` the canonical interpretation module:
 
@@ -21,8 +27,13 @@ Before anything else, `Read` the canonical interpretation module:
 ${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
 ```
 
-Its "Ad-hoc query routing" section owns the tree-vs-query decision rule and
-the provenance rules for presenting query results.
+Its "Ad-hoc query routing" section owns the tree-vs-plan-vs-query decision
+rule and the provenance rules for presenting results. If the composed-plan
+path is available (Step 1), also `Read` the plan-authoring protocol:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/compose-authoring/SKILL.md
+```
 
 ## Step 1: Check CLI availability and capability
 
@@ -54,6 +65,15 @@ that includes the query command (qluent-cli#92), then retry `/qluent:query`.
 
 Do not fall back to guessing tree commands or writing SQL yourself.
 
+Also probe the composed-plan capability (newer CLI + backend):
+
+```bash
+qluent plan --help
+```
+
+Non-zero / unknown subcommand simply means the compose path is unavailable —
+skip Step 3 and answer via the NL query. Never stop for this.
+
 ## Step 2: Routing check
 
 Apply the skill's ad-hoc query routing rule to `$ARGUMENTS` (minus any
@@ -62,7 +82,46 @@ Apply the skill's ad-hoc query routing rule to `$ARGUMENTS` (minus any
 catalog, redirect to `/qluent:investigate` instead of running an ad-hoc query,
 and say why in one sentence.
 
-## Step 3: Run the query
+## Step 3: Try a composed plan first
+
+Skip this step when the compose capability probe failed, or when this is a
+follow-up on an existing NL-query thread (`--thread <id>` given).
+
+Fetch the query catalog once per session (reuse `/tmp/qluent-catalog.json` if
+it already exists):
+
+```bash
+umask 077
+[ -s /tmp/qluent-catalog.json ] || qluent catalog --json-output > /tmp/qluent-catalog.json
+jq '{bases: (.catalog.bases | map_values({columns})), metrics: .catalog.metrics, relationships: .catalog.relationships, derived_dimensions: .catalog.derived_dimensions}' /tmp/qluent-catalog.json
+```
+
+If the catalog command reports the project has no query catalog, fall through
+to Step 4.
+
+Decide coverage: the question's relations, metrics, dimensions and filters
+must all map to catalog vocabulary (aliases count). If anything essential is
+missing, fall through to Step 4 and say which vocabulary was missing.
+
+Otherwise author the plan per the `compose-authoring` skill, `Write` it to
+`/tmp/qluent-plan.json`, and run:
+
+```bash
+set -o pipefail
+umask 077
+rm -f /tmp/qluent-plan-result.json
+qluent plan --file /tmp/qluent-plan.json --json-output | tee /tmp/qluent-plan-result.json >/dev/null
+jq '{status, error_code, error, row_count, grain}' /tmp/qluent-plan-result.json
+```
+
+- `status: "ok"` — present per Step 6 (composed-plan variant). Done; skip
+  Steps 4-5.
+- `status: "plan_invalid"` — the `error` is a repair instruction: fix the plan
+  per the skill and re-run, at most 3 repair rounds. If the errors show the
+  catalog genuinely lacks the vocabulary, fall through to Step 4 and say so.
+- Anything else (hard error) — fall through to Step 4.
+
+## Step 4: Run the NL query
 
 Warn the user once before the first run:
 
@@ -109,7 +168,7 @@ If qluent exits non-zero:
 - If the stream was interrupted, suggest re-running the same command.
 - Do not synthesize an answer from partial shell text.
 
-## Step 4: Clarification loop
+## Step 5: Clarification loop (NL query only)
 
 Check the saved payload's `status` with `jq`. If it is `clarification_needed`,
 present the clarification `message` and its `options` to the user with
@@ -126,46 +185,64 @@ rm -f /tmp/qluent-query-result.json
 qluent query "$answer" --thread <thread_id> --json-output | tee /tmp/qluent-query-result.json
 ```
 
-(The answer text is user-controlled too — same quoted-heredoc rule as Step 3.
+(The answer text is user-controlled too — same quoted-heredoc rule as Step 4.
 The `<thread_id>` comes from the previous qluent response, so plain
 substitution is fine there.)
 
 Cap the loop at 3 rounds; after that, report the open ambiguity to the user
 instead of looping further.
 
-## Step 5: Present the result
+## Step 6: Present the result
 
 Extract fields from the saved file with `jq` rather than dumping the full
-payload (it can hold up to 1000 rows) into the conversation:
+payload (it can hold up to 1000 rows) into the conversation.
+
+For an NL-query result:
 
 ```bash
 jq '{status, answer, sql, columns, row_count, truncated, thread_id, download_url, google_sheets_url}' /tmp/qluent-query-result.json
 jq '.data[:20]' /tmp/qluent-query-result.json
 ```
 
+For a composed-plan result:
+
+```bash
+jq '{status, sql, columns, row_count, grain, metrics, plan_summary}' /tmp/qluent-plan-result.json
+jq '.data[:20]' /tmp/qluent-plan-result.json
+```
+
 The payload shape may evolve with the CLI, so inspect fields by meaning rather
 than hardcoding one exact schema. Compose the reply:
 
-- Lead with the `answer`.
+- Lead with the direct answer to the question (NL results carry an `answer`;
+  for plan results state it from the rows yourself).
 - Render a compact markdown table of the first ~20 rows, noting
   "showing N of M rows" when `truncated` or `row_count` exceeds what you show.
-- Show the returned `sql` in a code block and check it matches the user's
-  intent before presenting numbers; flag mismatches instead of papering over
-  them.
-- Always surface `Query thread: <thread_id>` plus the `download_url` /
-  `google_sheets_url` links when present.
-- Label provenance per the skill: these numbers come from an ad-hoc query
-  (the SQL above), not from a deterministic tree investigation.
+- Show the returned `sql` in a code block. For NL results, check it matches
+  the user's intent before presenting numbers; flag mismatches instead of
+  papering over them. (A plan result's SQL is compiled from your plan — no
+  intent check needed, but show it for transparency.)
+- NL results: always surface `Query thread: <thread_id>` plus the
+  `download_url` / `google_sheets_url` links when present.
+- Plan results: respect `grain` and `metrics[*].summable` before doing any
+  arithmetic across results (see the `compose-authoring` skill).
+- Label provenance per the skill: "composed query (deterministic)" for plan
+  results, "ad-hoc query" for NL results — neither is deterministic tree
+  evidence.
 
 ## Rules
 
-- Check for qluent and the `query` subcommand before running.
+- Check for qluent and the `query` subcommand before running; probe `plan`
+  and prefer it when the catalog covers the question.
 - Follow the `qluent-interpretation` skill for routing, provenance labeling,
-  and the boundary between ad-hoc results and tree-derived attribution.
-- Follow-ups on the same result reuse `--thread <thread_id>`.
+  and the boundary between ad-hoc results and tree-derived attribution; the
+  `compose-authoring` skill owns plan authoring and repair.
+- Follow-ups on an NL result reuse `--thread <thread_id>`; follow-ups on a
+  plan result modify the plan document and re-run `qluent plan`.
 - For charts over the result, offer
-  `/qluent:visualize --file /tmp/qluent-query-result.json`
+  `/qluent:visualize --file /tmp/qluent-query-result.json` (or
+  `--file /tmp/qluent-plan-result.json`)
   (insight-driven HTML; the `--simple` renderer does not support query
   payloads).
-- Never write or edit SQL yourself; the backend owns SQL generation. Re-ask
-  through `qluent query` instead.
+- Never write or edit SQL yourself; the backend owns SQL generation. Author
+  plans, or re-ask through `qluent query`.

--- a/plugins/qluent/commands/visualize.md
+++ b/plugins/qluent/commands/visualize.md
@@ -32,14 +32,22 @@ deep-dive or cross-tree result, use that file instead. Deep-dive bundles must be
 JSON with a bundle-level `trees[]` array; if validation fails, report the failing path
 and re-run command instead of hand-writing replacement HTML.
 
-**Ad-hoc query results:** if the source is `/tmp/qluent-query-result.json`
-(via `--file`, or the payload carries `sql` plus `data` rows from
-`qluent query`), skip the report spec entirely and go straight to
+**Tabular query results:** if the source is `/tmp/qluent-query-result.json`
+or `/tmp/qluent-plan-result.json` (via `--file`), or the payload carries
+`sql` plus `data` rows from either query engine, skip the report spec
+entirely and go straight to
 insight-driven HTML mode via the `dashboard-design` skill: the `RcaReportSpec`
 sections are outcome/RCA-shaped and have no honest mapping for an arbitrary
-tabular result. Compose chart/table sections from the payload's `columns`,
-`data`, and answer text, and label the provenance as an ad-hoc query with its
-SQL. `--simple` is unsupported for query payloads — the generic renderer
+tabular result. Compose chart/table sections from the payload's `columns` and
+`data`, plus `answer` for an NL result or `plan_summary` for a plan result.
+Preserve the engine-specific provenance:
+
+- `qluent.query.v1`: label it "ad-hoc query" and cite its SQL.
+- `qluent.plan.v1`: label it "composed query (deterministic)", cite its SQL,
+  and preserve `grain` and `metrics[*].summable` constraints in any
+  cross-result arithmetic.
+
+`--simple` is unsupported for query payloads — the generic renderer
 template is investigation-shaped and would render empty. For small results, a
 markdown table in the reply is a fine alternative to a dashboard.
 

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -86,7 +86,7 @@ print()
 print('Unsupported cuts: the post-bash hook surfaces the closest companion tree per the algorithm in the qluent-interpretation skill. Follow its suggestion and synthesize both views.')
 print()
 print('Business-language routing hints: revenue/sales/GMV/AOV -> revenue; growth/users/acquisition/reactivation -> growth; delivery/late/failed/courier/ops quality -> operations; conversion/checkout/cart/traffic/payment -> conversion_funnel.')
-print('No tree match? Ad-hoc, row-level, entity-lookup, or SQL-shaped questions route to qluent query (slash command /qluent:query) per the qluent-interpretation skill. KPI movement/RCA questions stay on the trees above.')
+print('No tree match? Ad-hoc, row-level, entity-lookup, or SQL-shaped questions route per the qluent-interpretation skill (slash command /qluent:query): a composed plan first when the query catalog covers the question, else qluent query. KPI movement/RCA questions stay on the trees above.')
 print('On first run, orient the user from this tree metadata and offer one concrete first command. Use qluent whoami/status/suggestions only when available; do not probe unsupported project/status commands.')
 print('After an investigation, offer an RCA report, mix-shift report, or elasticity report through /qluent:visualize before any local HTML fallback.')
 print()
@@ -95,4 +95,39 @@ print('Ask a business performance question or use /qluent:investigate to start, 
 
 if [ -n "$context" ]; then
   echo "$context"
+fi
+
+# Composed-plan capability probe (newer CLI + backend). Runs even when no
+# metric trees exist -- a catalog-only project still gets the plan path. Fails
+# silently on CLIs without `qluent plan`; a loadable catalog is cached at the
+# session path the compose-authoring skill expects, so later plan authoring
+# skips the re-fetch.
+compose_context=""
+if qluent plan --help &>/dev/null; then
+  catalog_err=$(mktemp)
+  if catalog_json=$(qluent catalog --json-output 2>"$catalog_err"); then
+    (umask 077; printf '%s' "$catalog_json" > /tmp/qluent-catalog.json)
+    compose_context=$(printf '%s' "$catalog_json" | "$python_bin" -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    catalog = data.get('catalog') or {}
+    bases = catalog.get('bases') or {}
+    metrics = catalog.get('metrics') or {}
+except Exception:
+    sys.exit(0)
+if not bases:
+    sys.exit(0)
+print(f'[Qluent] Query catalog available: {len(bases)} bases, {len(metrics)} metrics (cached at /tmp/qluent-catalog.json).')
+print('For ad-hoc aggregations, breakdowns and rankings the catalog covers, prefer a composed plan (qluent plan; protocol in the compose-authoring skill) over the NL qluent query -- deterministic and catalog-checked.')
+" 2>/dev/null) || compose_context=""
+  elif grep -q 'QUERY_CATALOG_INVALID' "$catalog_err" 2>/dev/null; then
+    compose_context='[Qluent] This project has a query_catalog that fails to load (fix it under the Model tab) -- composed plans are unavailable until then; ad-hoc questions fall back to qluent query.'
+  fi
+  rm -f "$catalog_err"
+fi
+
+if [ -n "$compose_context" ]; then
+  echo ""
+  echo "$compose_context"
 fi

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -102,11 +102,14 @@ fi
 # silently on CLIs without `qluent plan`; a loadable catalog is cached at the
 # session path the compose-authoring skill expects, so later plan authoring
 # skips the re-fetch.
+compose_catalog=/tmp/qluent-catalog.json
 compose_context=""
+# The fixed path outlives a Claude session; never reuse another project's catalog.
+rm -f "$compose_catalog"
 if qluent plan --help &>/dev/null; then
   catalog_err=$(mktemp)
   if catalog_json=$(qluent catalog --json-output 2>"$catalog_err"); then
-    (umask 077; printf '%s' "$catalog_json" > /tmp/qluent-catalog.json)
+    (umask 077; printf '%s' "$catalog_json" > "$compose_catalog")
     compose_context=$(printf '%s' "$catalog_json" | "$python_bin" -c "
 import sys, json
 try:

--- a/plugins/qluent/skills/compose-authoring/SKILL.md
+++ b/plugins/qluent/skills/compose-authoring/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: compose-authoring
+description: Canonical protocol for authoring typed QueryPlans against a project's query catalog — node vocabulary, authoring rules, the plan_invalid repair loop, and cross-result composition safety. Loaded by qluent commands and agents; user-invocable for protocol inspection.
+user-invocable: true
+---
+
+# Composed query authoring protocol
+
+`qluent plan` compiles a typed QueryPlan you author against the project's
+closed-world query catalog. It is **deterministic** (the same plan always
+produces the same SQL) and **correct-by-construction**: the compiler rejects
+anything outside the catalog with a repairable message instead of executing
+plausible-but-wrong SQL. You author the plan; the backend owns the SQL.
+
+This skill is the single source of truth for plan authoring. Commands and
+agents should reference it by name rather than restating the rules.
+
+## The catalog is the vocabulary
+
+Fetch it once per session and cache it:
+
+```bash
+umask 077
+qluent catalog --json-output > /tmp/qluent-catalog.json
+jq '{bases: (.catalog.bases | map_values({columns})), metrics: .catalog.metrics, relationships: .catalog.relationships, derived_dimensions: .catalog.derived_dimensions, aliases: .catalog.column_aliases}' /tmp/qluent-catalog.json
+```
+
+Everything a plan references must come from this vocabulary:
+
+- `catalog.bases` — the relations a `source` node may read, with their
+  columns, scope keys and date columns.
+- `catalog.metrics` — metric name → the bases that can compute it. Pair each
+  metric with a base from its own list; the compiler rejects mismatches.
+- `catalog.relationships` — the ONLY joins allowed. Each names its two bases,
+  key columns, and cardinality.
+- `catalog.derived_dimensions` — computed dims (time buckets like
+  `order_month`, segment buckets) usable directly in `group_by.dims`.
+- `catalog.column_aliases` / `value_aliases` — accepted alternative
+  spellings. When unsure of a value's exact spelling, prefer `contains`
+  filters over `=`.
+- `plan_schema` — the JSON schema the plan document must satisfy.
+
+## Plan shape
+
+A plan is a DAG of nodes, each with a unique `id` (letters/digits/underscores,
+not a SQL keyword), reading inputs by id. `output` names the terminal node.
+
+```json
+{
+  "nodes": [
+    {"op": "source", "id": "src", "base": "orders_successful_base"},
+    {"op": "filter_by", "id": "f", "input": "src", "column": "business_type",
+     "operator": "=", "value": "restaurants"},
+    {"op": "group_by", "id": "g", "input": "f",
+     "dims": ["order_month"], "metrics": ["gfv", "order_count"]},
+    {"op": "top_k", "id": "top", "input": "g", "by": "gfv", "n": 10}
+  ],
+  "output": "top",
+  "params": {"date_range": {"start": "2026-01-01", "end": "2026-04-01"}}
+}
+```
+
+Node vocabulary:
+
+| op | fields | notes |
+|---|---|---|
+| `source` | `base` | leaf; reads a catalog base |
+| `filter_by` | `column`, `operator`, `value` | operators: `=`, `!=`, `>`, `<`, `>=`, `<=`, `in`, `not in`, `between`, `not between`, `like`, `not like`, `contains`, `starts_with`. Numbers as JSON numbers (enables HAVING-style filters after group_by); lists only for `in`/`not in`; `[low, high]` for between. `contains`/`starts_with` are case-insensitive and escape wildcards |
+| `group_by` | `dims`, `metrics` | dims may be columns or derived dimensions; metrics from the catalog |
+| `aggregate` | `metrics` | grand total, no dims |
+| `top_k` | `by`, `n`, `direction` | rank + limit |
+| `distinct` | `columns` | unique values |
+| `select_columns` | `columns` | narrow projection |
+| `add_derived_dims` | `names` | materialize derived dims without grouping |
+| `join` | `left`, `right`, `how`, `relationship` | `relationship` must name a catalog relationship when any exist |
+| `set_op` | `kind`, `inputs` | `union`/`union_all`/`intersect`/`except`; inputs need identical columns |
+| `window` | `windows[]` | each: `func` (`running_total`/`delta`/`growth_pct`/`share_of_total`/`rank`), `value`, `order_by`, `partition_by`, `direction`, `as_name` |
+
+`params` (top-level, not nodes): `date_range` (`start` inclusive, `end`
+EXCLUSIVE), `currency` (`eur`/`local`), `global_entity_id` / `country_name`
+(market scope).
+
+## Authoring rules
+
+1. **Date windows go in `params.date_range`**, never in a `filter_by` — the
+   compiler applies them to the base's date column with partition pruning.
+2. **Set market scope in `params.global_entity_id`** when the question names a
+   market or your access is market-scoped. A `PLAN_SCOPE_VIOLATION` error
+   means exactly this.
+3. **Aggregate early.** `group_by` before `join`/`top_k`/`window`; join small
+   aggregates on shared dims rather than joining raw bases (row-grain joins
+   of additive metrics are rejected as double-counting).
+4. **Period-over-period** = `group_by` on a time-grain derived dim (month →
+   MoM, year → YoY), then `window` with `growth_pct` ordered by that dim.
+   "Top N per group" = `window` `rank` with `partition_by`, then `filter_by`
+   on the rank column. Place `window` after `group_by`.
+5. **HAVING** = `filter_by` with a numeric value *after* `group_by`.
+6. Copy catalog spellings exactly; `window.as_name` must not collide with an
+   existing column.
+
+## The repair loop
+
+Write the plan to a private file and run:
+
+```bash
+umask 077
+qluent plan --file /tmp/qluent-plan.json --json-output > /tmp/qluent-plan-result.json
+jq '{status, error_code, error}' /tmp/qluent-plan-result.json
+```
+
+- `status: "ok"` — proceed to presentation.
+- `status: "plan_invalid"` — a repair instruction, not a failure. The `error`
+  names what was wrong and what IS valid (available columns, the bases a
+  metric works on, the relationship a join needs). Fix exactly that and
+  re-run. Cap at 3 repair rounds.
+- Re-running an *unchanged* plan is pointless; a *corrected* plan is expected.
+- Fall back to `qluent query` (NL) only when the error shows the catalog
+  genuinely lacks the vocabulary — a column, metric, or relationship that
+  does not exist — or the shape needs SQL the node algebra cannot express.
+  Say which vocabulary was missing when you fall back.
+
+## Composing multiple results
+
+Complex questions often decompose into several small plans whose results you
+combine. Two fields in every result exist to keep that safe:
+
+- `grain` — the columns that uniquely identify one result row. Only align
+  results on their grain; never join two results on columns that are not the
+  grain of at least one side.
+- `metrics[*].summable` — whether values may be ADDED across result sets.
+  Sums and row counts are summable. Averages, ratios (`kind: "ratio"`), and
+  distinct counts (`kind: "count_distinct"`) are NOT: recompute them from
+  their summable parts, or get them from one plan at the right grain instead.
+
+Prefer one plan with an extra `group_by` dim over N single-value plans — the
+compiler and the database do the composition better than post-hoc arithmetic.
+
+## Provenance
+
+Composed results are deterministic: the same plan always compiles to the same
+SQL against the catalog. Label them "composed query (deterministic)" and cite
+the returned `sql` (and plan on request). They are still NOT tree evidence —
+never blend them into Shapley attribution or other tree-derived claims; the
+`qluent-interpretation` skill owns that boundary.

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -301,9 +301,10 @@ updating that allowlist on purpose.
   is the durable handle for continuing the conversation, not this file.
 
 ### `/tmp/qluent-catalog.json` — session query catalog
-- **Producer:** the first `qluent catalog --json-output` of the session
-  (written by `/qluent:query` or any agent following the `compose-authoring`
-  skill).
+- **Producer:** `scripts/session-start.sh` writes it at session start when the
+  CLI/backend support composed plans; otherwise the first
+  `qluent catalog --json-output` of the session (written by `/qluent:query` or
+  any agent following the `compose-authoring` skill).
 - **Consumers:** plan authoring reads the vocabulary (`catalog.*`) and the
   QueryPlan JSON schema (`plan_schema`) from it instead of re-fetching.
 - **Schema:** the `qluent.catalog.v1` contract — `catalog` (bases, metrics,

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -35,14 +35,15 @@ Always use `--json-output`.
 
 ## Ad-hoc query routing
 
-**Trees first, query as fallback — trees win ties.**
+**Trees first, composed plans second, NL query last — the more deterministic
+engine wins ties.**
 
 Route to a metric tree (`/qluent:investigate`, `qluent-analyst` tree workflow)
 when the question is about a KPI's level, movement, trend, drivers, mix, or
 sensitivity AND it maps to a configured tree's root metric, child node, or
 declared dimension in the session catalog.
 
-Route to `qluent query` when ANY of these hold:
+Route away from trees when ANY of these hold:
 
 1. **Row/entity level** — the question needs individual records or entities
    (specific orders, customers, transactions; "list", "show me",
@@ -56,20 +57,31 @@ Route to `qluent query` when ANY of these hold:
 4. **Explicit raw-data ask** — the user wants a table, an export, a
    spreadsheet, or the SQL itself.
 
-Trees win ties: if a tree can answer deterministically, use the tree. Never
-decline a data question because no tree matches — fall back to `qluent query`.
-Never use `qluent query` to re-derive numbers a tree investigation already
-returned.
+For those questions, prefer a **composed plan** (`qluent plan`, protocol in
+the `compose-authoring` skill) whenever the CLI supports it and the project's
+query catalog (`qluent catalog`) covers the question's bases, metrics and
+dimensions: composed plans are deterministic and catalog-checked. Use the NL
+`qluent query` only when the catalog lacks the vocabulary, the shape exceeds
+the plan node algebra, or the CLI/backend predates the compose surface.
 
-Ad-hoc results are produced by LLM-generated SQL, not the deterministic tree
-engine. They are not deterministic tree evidence: label their provenance as
-"ad-hoc query" (with the returned SQL as the citation), never blend them into
-Shapley attribution or other tree-derived claims, and verify the returned
-`sql` matches the user's intent before presenting numbers. Run with
-`qluent query "<question>" --json-output`, check `status`
-(`ok` / `clarification_needed` / `error`), and answer clarifications or ask
-follow-ups by re-running with `--thread <thread_id>` from the previous
-response.
+Trees win ties: if a tree can answer deterministically, use the tree; between
+a composed plan and the NL query, the plan wins. Never decline a data question
+because no tree matches — fall through plan, then NL query. Never re-derive
+numbers a tree investigation already returned.
+
+Provenance labels differ by engine:
+
+- **Composed plan** results compile deterministically from the closed-world
+  catalog: label them "composed query (deterministic)" and cite the returned
+  `sql`. They are still not tree evidence — never blend them into Shapley
+  attribution or other tree-derived claims.
+- **NL query** results are produced by LLM-generated SQL: label them "ad-hoc
+  query" (with the returned SQL as the citation) and verify the returned
+  `sql` matches the user's intent before presenting numbers. Run with
+  `qluent query "<question>" --json-output`, check `status`
+  (`ok` / `clarification_needed` / `error`), and answer clarifications or ask
+  follow-ups by re-running with `--thread <thread_id>` from the previous
+  response.
 
 ## Windows
 
@@ -287,6 +299,26 @@ updating that allowlist on purpose.
   `{message, options}`.
 - **Freshness:** holds only the most recent round; the `thread_id` inside it
   is the durable handle for continuing the conversation, not this file.
+
+### `/tmp/qluent-catalog.json` — session query catalog
+- **Producer:** the first `qluent catalog --json-output` of the session
+  (written by `/qluent:query` or any agent following the `compose-authoring`
+  skill).
+- **Consumers:** plan authoring reads the vocabulary (`catalog.*`) and the
+  QueryPlan JSON schema (`plan_schema`) from it instead of re-fetching.
+- **Schema:** the `qluent.catalog.v1` contract — `catalog` (bases, metrics,
+  relationships, derived_dimensions, aliases) and `plan_schema`.
+
+### `/tmp/qluent-plan.json` / `/tmp/qluent-plan-result.json` — composed plan round
+- **Producer:** plan authoring per the `compose-authoring` skill writes the
+  QueryPlan document to `/tmp/qluent-plan.json` and tees the `qluent plan`
+  result to `/tmp/qluent-plan-result.json`; each repair round overwrites both.
+- **Consumers:** the repair loop reads `status`/`error`;
+  `/qluent:visualize --file` reads the result for tabular charts the same way
+  it reads query results.
+- **Schema:** the `qluent.plan.v1` contract — `status`
+  (`ok` / `plan_invalid` / `error`), `sql`, `columns`, `data`, `row_count`,
+  `grain`, `metrics` (per-metric `kind` + `summable`), `plan_summary`.
 
 ### `/tmp/qluent-tree-capabilities.json` — session tree catalog
 - **Producer:** `scripts/session-start.sh` writes the normalized catalog

--- a/tests/test_query_contract.sh
+++ b/tests/test_query_contract.sh
@@ -90,17 +90,25 @@ assert_contains "$SKILL" '/tmp/qluent-query-result.json'
 
 # 3. Routing consumers point at the query path.
 assert_contains "$ANALYST" 'qluent query'
+assert_contains "$ANALYST" '  - compose-authoring'
+assert_contains "$ANALYST" 'qluent plan --help'
+assert_contains "$ANALYST" 'qluent catalog --json-output'
+assert_contains "$ANALYST" '/tmp/qluent-plan-result.json'
+assert_contains "$ANALYST" 'composed query (deterministic)'
 assert_contains "$SESSION_START" '/qluent:query'
 
 # 4. Docs advertise the command; visualize declares the renderer boundary.
 assert_contains "$README" '/qluent:query'
 assert_contains "$PLUGIN_CLAUDE" '/qluent:query'
+assert_contains "$VISUALIZE" '/tmp/qluent-plan-result.json'
+assert_contains "$VISUALIZE" 'composed query (deterministic)'
 assert_contains "$VISUALIZE" '`--simple` is unsupported for query payloads'
 
 # 5. Hook behavior against fixture payloads.
 tmpdir="$(mktemp -d)"
 query_file="/tmp/qluent-query-result.json"
 viz_file="/tmp/qluent-viz-data.json"
+catalog_file="/tmp/qluent-catalog.json"
 
 restore_tmp_files() {
   rm -f "$query_file" "$viz_file"
@@ -109,6 +117,11 @@ restore_tmp_files() {
   fi
   if [ -f "$tmpdir/viz-data.bak" ]; then
     cp "$tmpdir/viz-data.bak" "$viz_file"
+  fi
+  if [ -f "$tmpdir/catalog.bak" ]; then
+    cp "$tmpdir/catalog.bak" "$catalog_file"
+  else
+    rm -f "$catalog_file"
   fi
   rm -rf "$tmpdir"
 }
@@ -119,7 +132,32 @@ fi
 if [ -f "$viz_file" ]; then
   cp "$viz_file" "$tmpdir/viz-data.bak"
 fi
+if [ -f "$catalog_file" ]; then
+  cp "$catalog_file" "$tmpdir/catalog.bak"
+fi
 trap restore_tmp_files EXIT
+
+# 5a. A failed catalog probe must invalidate a cache from an earlier project.
+mkdir -p "$tmpdir/bin"
+cat > "$tmpdir/bin/qluent" <<'SH'
+#!/usr/bin/env bash
+if [ "$1 $2 $3" = "trees list --json-output" ]; then
+  printf '{"trees":[]}'
+  exit 0
+fi
+if [ "$1 $2" = "plan --help" ]; then
+  exit 0
+fi
+if [ "$1 $2" = "catalog --json-output" ]; then
+  echo 'QUERY_CATALOG_INVALID' >&2
+  exit 1
+fi
+exit 1
+SH
+chmod +x "$tmpdir/bin/qluent"
+printf '{"catalog":{"bases":{"stale_project":{}}}}' > "$catalog_file"
+PATH="$tmpdir/bin:$PATH" bash "$SESSION_START" >/dev/null
+[ ! -e "$catalog_file" ] || fail "session start should remove a stale catalog when the current project catalog fails"
 
 QUERY_TOOL_INPUT='{"command":"qluent query \"top customers by refunds\" --json-output | tee /tmp/qluent-query-result.json"}'
 

--- a/tests/test_session_paths.sh
+++ b/tests/test_session_paths.sh
@@ -107,22 +107,28 @@ check_path '/tmp/qluent-query-result.json' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-catalog.json' \
+  'plugins/qluent/agents/qluent-analyst.md' \
   'plugins/qluent/commands/query.md' \
   'plugins/qluent/scripts/session-start.sh' \
   'plugins/qluent/skills/compose-authoring/SKILL.md' \
   'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_query_contract.sh' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-plan.json' \
+  'plugins/qluent/agents/qluent-analyst.md' \
   'plugins/qluent/commands/query.md' \
   'plugins/qluent/skills/compose-authoring/SKILL.md' \
   'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-plan-result.json' \
+  'plugins/qluent/agents/qluent-analyst.md' \
   'plugins/qluent/commands/query.md' \
+  'plugins/qluent/commands/visualize.md' \
   'plugins/qluent/skills/compose-authoring/SKILL.md' \
   'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_query_contract.sh' \
   'tests/test_session_paths.sh'
 
 echo "session paths tests passed"

--- a/tests/test_session_paths.sh
+++ b/tests/test_session_paths.sh
@@ -106,4 +106,23 @@ check_path '/tmp/qluent-query-result.json' \
   'tests/test_query_contract.sh' \
   'tests/test_session_paths.sh'
 
+check_path '/tmp/qluent-catalog.json' \
+  'plugins/qluent/commands/query.md' \
+  'plugins/qluent/scripts/session-start.sh' \
+  'plugins/qluent/skills/compose-authoring/SKILL.md' \
+  'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_session_paths.sh'
+
+check_path '/tmp/qluent-plan.json' \
+  'plugins/qluent/commands/query.md' \
+  'plugins/qluent/skills/compose-authoring/SKILL.md' \
+  'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_session_paths.sh'
+
+check_path '/tmp/qluent-plan-result.json' \
+  'plugins/qluent/commands/query.md' \
+  'plugins/qluent/skills/compose-authoring/SKILL.md' \
+  'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_session_paths.sh'
+
 echo "session paths tests passed"


### PR DESCRIPTION
Third of three PRs positioning the compose engine as an agent-facing query surface (qluent/qluent-ui#506 → qluent/qluent-cli#96 → **this**).

## What

Claude becomes the plan author. Instead of always shipping the user's question as a string to the backend's LLM workflow, `/qluent:query` now fetches the project's query catalog once per session and authors a typed QueryPlan itself — with full conversation context and its own repair loop — submitting via `qluent plan`. The NL workflow remains the fallback.

- **New `compose-authoring` skill** — the canonical plan-authoring protocol, mirroring how `qluent-interpretation` centralizes analysis rules: catalog vocabulary, node reference, authoring rules (date windows in `params`, aggregate-early, scope via `params.global_entity_id`, PoP via time-grain + `growth_pct`), the `plan_invalid` repair loop (max 3 rounds, fall back only when vocabulary is genuinely missing), and **cross-result composition safety**: only `summable` metrics may be added across results; align results on `grain`.
- **`qluent-interpretation` routing becomes three-tier**: trees → composed plan → NL query, "Trees win ties" preserved (test-pinned). Composed results get their own provenance label — *"composed query (deterministic)"* — a middle evidence tier between tree results and ad-hoc SQL; still excluded from Shapley blending. Session paths documented for `/tmp/qluent-catalog.json` and `/tmp/qluent-plan{,-result}.json`.
- **`/qluent:query`** probes `qluent plan --help` (older CLIs skip the plan path silently — never a hard stop), keeps the load-bearing quoted-heredoc/`pipefail`/`umask` hygiene for the NL path unchanged, and extends presentation with the plan variant (grain/summable notes, no intent-check needed on compiled SQL).

## Why

The current stack sends a question from a strong reasoning agent to a deliberately-constrained server-side LLM call. Compose inverts that: the agent authors, the compiler guarantees. Deterministic, catalog-checked, repairable-on-error — and the plugin's own "not deterministic tree evidence" caveat no longer applies to this class of answers.

## Tests

All 9 plugin test scripts pass (`test_protocol_locality` / `test_query_contract` pin the "Trees win ties" phrase, kept).

Requires qluent/qluent-cli#96 (which requires qluent/qluent-ui#506). Safe to merge ahead: the capability probe keeps old CLIs on the NL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
