### PR TITLE
feat: make querying the default plugin workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Qluent plugin for Claude Code
 
-Deterministic KPI analysis inside Claude Code. Ask why a metric changed and get
-an answer backed by Shapley attribution — not vibes.
+Business querying and deterministic KPI analysis inside Claude Code. Start
+with the connected catalog; add metric trees when you need governed RCA.
 
 ## Getting Started
 
@@ -35,13 +35,15 @@ Or use slash commands directly:
 
 | Command | What it does |
 |---|---|
+| `/qluent:query` | Default workflow for business and data questions; deterministic composed plan when catalog-covered, NL-to-SQL fallback otherwise |
 | `/qluent:deep-dive` | Cross-tree executive narrative across all configured metric trees |
-| `/qluent:investigate` | Full analysis: validation, trend, evaluation, and RCA |
+| `/qluent:investigate` | Advanced deterministic analysis: validation, trend, evaluation, and RCA |
 | `/qluent:visualize` | Shape the latest analysis into an `RcaReportSpec` (or local HTML fallback) |
-| `/qluent:query` | Ad-hoc natural-language data question answered via SQL (row-level, entity lookups, cuts outside the trees) |
 | `/qluent:setup` | Check installation and configuration |
 
-Start with `/qluent:investigate` for a specific metric tree. Use
+Start with `/qluent:query` for general business and data questions. Use
+`/qluent:investigate` when you explicitly need governed KPI decomposition,
+attribution, trend, or lever evidence from a configured tree. Use
 `/qluent:deep-dive` when you need one executive read across the whole business.
 `/qluent:investigate` already bundles trend, RCA, and segment data; the qluent
 agents run any deeper follow-ups directly against the qluent CLI when the
@@ -68,15 +70,14 @@ Requires a qluent CLI release that includes `qluent trees deep-dive` from
 `qluent-cli#40`. See `/qluent:deep-dive` for the full workflow contract,
 including the synthesis shape and per-tree caveat handling.
 
-## Ad-hoc queries
+## Query-first workflow
 
-`/qluent:query <question>` answers data questions no metric tree covers —
-the trees answer "why did the KPI move"; `/qluent:query` answers everything
-else (row-level lookups, entity lists, arbitrary cuts and exports). It runs
-the qluent backend's natural-language-to-SQL workflow, so it can take a few
-minutes, may ask a clarifying question first, and returns the generated SQL,
-an inline result table, and a download link. Follow-ups continue the same
-conversation via the returned thread id:
+`/qluent:query <question>` is the default entry point. It first uses the
+project catalog to compose a deterministic QueryPlan when coverage is
+complete, then falls back to the backend's natural-language-to-SQL workflow.
+The fallback can take a few minutes and may ask a clarifying question.
+Metric trees remain available as the advanced workflow for governed movement
+analysis and RCA. Follow-ups on NL queries continue via the returned thread:
 
 ```bash
 /qluent:query which restaurants had the most failed deliveries last week?

--- a/plugins/qluent/CLAUDE.md
+++ b/plugins/qluent/CLAUDE.md
@@ -1,7 +1,7 @@
 # Qluent Metric Trees
 
-Deterministic KPI analysis from the command line. This plugin provides slash
-commands for investigating business metric movements using metric trees.
+Business querying and deterministic KPI analysis from the command line.
+Querying is the default workflow; metric trees add advanced movement analysis.
 
 ## Be proactive
 
@@ -37,19 +37,20 @@ anything.
 dimensions → segment drill-down; multiple trees → comparison; any tree → trend
 or weekly health check.
 
-**Show, don't tell:** when in doubt, run `/qluent:investigate` on the broadest
-tree for the latest period and present real findings.
+**Show, don't tell:** when in doubt, start from `qluent suggestions
+--json-output` and run `/qluent:query` with a catalog-backed question.
 
 ## Commands
 
-- `/qluent:investigate` — Primary entry point. Bundles validation, trend, evaluation, and RCA.
+- `/qluent:query` — Default entry point for business and data questions; composed plan first, NL-to-SQL fallback.
+- `/qluent:investigate` — Advanced deterministic KPI movement analysis. Bundles validation, trend, evaluation, and RCA.
 - `/qluent:deep-dive` — Opt-in cross-tree executive read. Confirms cost.
 - `/qluent:visualize` — Render the latest analysis as an `RcaReportSpec` (primary) or styled HTML (fallback).
-- `/qluent:query` — Ad-hoc natural-language data question answered via SQL over the warehouse.
 - `/qluent:setup` — Check installation and configuration.
 
-**Start with `/qluent:investigate` for single-tree questions and
-`/qluent:deep-dive` only when the user explicitly wants a cross-business view.**
+**Start with `/qluent:query`. Use `/qluent:investigate` when the user
+explicitly wants deterministic KPI movement, RCA, trend, mix, or lever
+analysis, and `/qluent:deep-dive` only for an explicit cross-business view.**
 The bundled `investigate` response already contains trend, RCA, and segment
 findings — for deeper follow-ups, the `qluent-analyst`, `trend-interpreter`,
 `rca-validator`, and `segment-explorer` agents run the underlying `qluent`

--- a/plugins/qluent/agents/qluent-analyst.md
+++ b/plugins/qluent/agents/qluent-analyst.md
@@ -1,9 +1,10 @@
 ---
 name: qluent-analyst
-description: Proactively use when the user asks about business metrics, KPI movements, revenue/cost/ROAS/conversion changes, or why a metric went up or down — or ad-hoc data questions (row-level lookups, entity lists, arbitrary cuts) which it answers via `qluent query` when no metric tree fits. Autonomously runs the full investigation workflow — investigate, then follow up with trend, RCA, or tree comparison as needed until the question is fully answered.
+description: Proactively answer business and data questions through the query workflow by default, using advanced metric-tree investigation for explicit deterministic KPI movement, RCA, trend, or lever requests.
 tools: Bash
 skills:
   - qluent-interpretation
+  - compose-authoring
 ---
 
 You are an autonomous KPI analyst that uses the qluent CLI to answer business
@@ -21,15 +22,13 @@ restate or paraphrase its rules.
 
 ## Proactive guidance
 
-When the question is vague or exploratory, run a lightweight analysis and
+When the question is vague or exploratory, start with query discovery and
 show what's possible.
 
-1. Check session context for available trees; if absent, run
-   `qluent trees list --json-output`.
-2. Pick the broadest-scope tree and investigate the most recent period.
-3. Summarize findings and suggest 2-3 follow-up questions tailored to the
-   data.
-4. Mention other available trees briefly.
+1. Run `qluent suggestions --json-output` and use the query suggestions first.
+2. Ask or answer one lightweight catalog-backed question.
+3. Suggest 2-3 follow-up questions tailored to the returned data.
+4. Mention metric trees only as an advanced option when configured.
 
 ## Workflow
 
@@ -38,11 +37,29 @@ rules in the `qluent-interpretation` skill first. Continue from a matching
 cached or fetched saved run when available instead of starting by rerunning the
 investigation.
 
-### Step 0: Route tree vs ad-hoc query
+### Step 0: Route query vs advanced metric-tree analysis
 
-Apply the skill's ad-hoc query routing rule first. When the question routes
-to an ad-hoc query (row/entity level, no tree coverage, SQL-shaped, or an
-explicit raw-data ask), run:
+Apply the skill's query-first routing rule. General business and data
+questions use the query workflow. Only explicit deterministic KPI movement,
+RCA, trend, mix, or lever requests with a matching configured tree proceed to
+Step 1.
+
+For the default query workflow, probe `qluent plan --help`. When available,
+load `qluent catalog --json-output` and follow the `compose-authoring`
+skill. If the catalog fully covers the question, author
+`/tmp/qluent-plan.json` and run:
+
+```bash
+set -o pipefail
+umask 077
+rm -f /tmp/qluent-plan-result.json
+qluent plan --file /tmp/qluent-plan.json --json-output | tee /tmp/qluent-plan-result.json
+```
+
+Repair `plan_invalid` responses per the skill. On success, present the
+result as a **composed query (deterministic)** and stop. If the compose
+capability is unavailable or catalog vocabulary is insufficient, use the NL
+fallback:
 
 ```bash
 set -o pipefail

--- a/plugins/qluent/commands/investigate.md
+++ b/plugins/qluent/commands/investigate.md
@@ -6,8 +6,8 @@ allowed-tools: Bash(qluent *), Read
 
 # Investigate KPI movement
 
-Primary entry point for metric analysis. Bundles validation, trend,
-evaluation, and root cause analysis in one call.
+Advanced deterministic entry point for KPI movement analysis. Bundles
+validation, trend, evaluation, and root cause analysis in one call.
 
 Follow the `qluent-interpretation` skill for tree resolution, window handling,
 provenance, Shapley/confidence interpretation, elasticity guardrails, and the
@@ -36,8 +36,19 @@ and resolve a tree (Step 2). If it is a single token (`revenue`, `roas`,
 ## Step 2: Resolve a tree
 
 Run `qluent trees list --json-output` and pick the best fit per the tree
-resolution rules in the `qluent-interpretation` skill. If no tree is a clear
-winner, ask the user to choose from the top candidates.
+resolution rules in the `qluent-interpretation` skill.
+
+If the project has zero trees, stop and explain:
+
+```text
+Metric-tree investigation is not configured for this project yet. It is an
+advanced deterministic capability, not a setup requirement. I can answer the
+question through /qluent:query instead.
+```
+
+Offer the equivalent query, but do not silently label query output as
+metric-tree evidence. If trees exist but no tree is a clear winner, ask the
+user to choose from the top candidates.
 
 ## Step 3: Resolve windows
 

--- a/plugins/qluent/commands/query.md
+++ b/plugins/qluent/commands/query.md
@@ -1,14 +1,14 @@
 ---
-description: Ask an ad-hoc data question — answered by a deterministic composed QueryPlan when the query catalog covers it, else via LLM-generated SQL over the warehouse (row-level, entity lookups, cuts outside the metric trees)
+description: Ask a business or data question — the default Qluent workflow, answered by a deterministic composed QueryPlan when the catalog covers it, else via LLM-generated SQL
 argument-hint: "<question> [--thread <id>]"
 allowed-tools: Bash(which qluent), Bash(qluent *), Bash(jq *), AskUserQuestion, Read, Write
 ---
 
-# Ad-hoc query (composed plan first, NL fallback)
+# Query (default workflow; composed plan first, NL fallback)
 
-Use when the user asks a data question the metric trees cannot answer:
-row-level or entity lookups, arbitrary aggregations or filters, or explicit
-raw-data requests. Two engines answer these, tried in order:
+Use for general business and data questions, including aggregations,
+breakdowns, rankings, row-level or entity lookups, arbitrary filters, and
+explicit raw-data requests. Two engines answer these, tried in order:
 
 1. **Composed plan** (`qluent plan`) — you author a typed QueryPlan against
    the project's query catalog; the backend compiles it deterministically.
@@ -27,7 +27,7 @@ Before anything else, `Read` the canonical interpretation module:
 ${CLAUDE_PLUGIN_ROOT}/skills/qluent-interpretation/SKILL.md
 ```
 
-Its "Ad-hoc query routing" section owns the tree-vs-plan-vs-query decision
+Its "Query-first routing" section owns the tree-vs-plan-vs-query decision
 rule and the provenance rules for presenting results. If the composed-plan
 path is available (Step 1), also `Read` the plan-authoring protocol:
 
@@ -76,11 +76,12 @@ skip Step 3 and answer via the NL query. Never stop for this.
 
 ## Step 2: Routing check
 
-Apply the skill's ad-hoc query routing rule to `$ARGUMENTS` (minus any
-`--thread <id>` flag). If the question is actually a KPI movement /
-"why did X change" question that maps to a configured tree in the session
-catalog, redirect to `/qluent:investigate` instead of running an ad-hoc query,
-and say why in one sentence.
+Apply the skill's query-first routing rule to `$ARGUMENTS` (minus any
+`--thread <id>` flag). Only redirect when the user explicitly asks for
+advanced deterministic KPI movement analysis (for example RCA, drivers,
+trend classification, or levers) and the session catalog contains a matching
+tree. General questions about a metric's value, breakdown, ranking, or change
+remain on the query workflow.
 
 ## Step 3: Try a composed plan first
 

--- a/plugins/qluent/commands/setup.md
+++ b/plugins/qluent/commands/setup.md
@@ -34,50 +34,60 @@ which qluent
 
 If installation fails or the user skips, stop here and report that qluent is not installed.
 
-## Step 2: Check configuration
+## Step 2: Check the effective connection and capabilities
 
 ```bash
-qluent config
+qluent status --json-output
 ```
 
-If the output shows an API key and project UUID, configuration is present.
+Use this result rather than `qluent config`: status reflects environment
+overrides as well as the saved config and verifies API access.
 
-If no config file is found or credentials are missing:
+If `connected` is false or the command reports missing credentials:
 - Tell the user to log in by running `!qluent login` in this session. This opens a browser for SSO authentication and automatically configures the API key, project, and email.
 - **Always recommend `qluent login` first** — it is the preferred auth method. Only mention `qluent setup` as a fallback for headless environments without a browser.
 - Do not attempt to run `qluent login` or `qluent setup` via Bash — these are interactive commands that require the `!` prefix.
 
-## Step 3: Verify access
+## Step 3: Start with query discovery
 
 ```bash
-qluent trees list
+qluent suggestions --json-output
 ```
 
-If trees are returned, qluent is fully ready. Report the number of available metric trees.
+Querying is the default Qluent workflow. Present the first 2–3
+catalog-derived query suggestions and explain that `/qluent:query` will use
+a deterministic composed plan when the catalog fully covers the question,
+then fall back to the NL-to-SQL workflow when needed.
 
-If the command fails with an auth error, the credentials may be invalid or expired. Tell the user to re-authenticate with `!qluent login`.
+Metric trees are an advanced, optional capability:
 
-If no trees are found, tell the user their workspace may not have any metric trees configured yet.
+- If `capabilities.metric_trees.count` is zero, say metric-tree
+  investigation is not configured for this project. This is informational,
+  not a setup warning or failure.
+- If trees exist, briefly mention that `/qluent:investigate` is available
+  for deterministic KPI decomposition, RCA, trends, and levers.
 
-## Step 4: Kick off exploration
+If suggestions fail with an auth error, tell the user to re-authenticate with
+`!qluent login`. If the project has no loadable query catalog, explain that
+questions can still fall back to `qluent query`.
 
-If Step 3 succeeded and trees are available, run the session-start hook to inject rich tree context:
+## Step 4: Inject project context
+
+For every connected project, run the session-start hook. Catalog-only
+projects need its query context just as much as tree-enabled projects:
 
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/session-start.sh"
 ```
 
-Then proactively suggest an initial investigation based on the available trees. For example:
-- If there's a revenue tree, offer to investigate recent revenue performance
-- If there are multiple trees, highlight what each one can answer
-- Tailor suggestions to the tree structure (dimensions → segment drill-down, children → root cause)
-
-The goal is to get the user into analysis immediately after setup, not leave them staring at a status summary.
+Then offer one concrete `/qluent:query` question from the suggestions. Do not
+make users configure a metric tree before they can start querying.
 
 ## Output
 
 Present a summary:
 - Installation: installed / not installed
-- Authentication: configured / not configured
-- Metric trees: N available (with descriptions and what each can answer)
-- Suggested first question based on available trees
+- Connection: ready / login required
+- Querying: ready (default), including catalog coverage when available
+- Metric trees: N available, or "not configured (advanced, optional)"
+- Suggested first query based on the project catalog

--- a/plugins/qluent/scripts/session-start.sh
+++ b/plugins/qluent/scripts/session-start.sh
@@ -41,6 +41,16 @@ except Exception:
     sys.exit(0)
 
 if not raw:
+    catalog_path = os.environ.get('QLUENT_TREE_CATALOG')
+    if catalog_path:
+        try:
+            with open(catalog_path, 'w', encoding='utf-8') as fh:
+                json.dump({'trees': []}, fh)
+        except Exception:
+            pass
+    print('[Qluent] Querying is ready and is the default workflow for this project.')
+    print('[Qluent] Metric trees are not configured (advanced, optional); deterministic KPI investigation is unavailable until a tree is published.')
+    print('Start with /qluent:query and a business or data question.')
     sys.exit(0)
 
 def norm(t):
@@ -86,11 +96,12 @@ print()
 print('Unsupported cuts: the post-bash hook surfaces the closest companion tree per the algorithm in the qluent-interpretation skill. Follow its suggestion and synthesize both views.')
 print()
 print('Business-language routing hints: revenue/sales/GMV/AOV -> revenue; growth/users/acquisition/reactivation -> growth; delivery/late/failed/courier/ops quality -> operations; conversion/checkout/cart/traffic/payment -> conversion_funnel.')
-print('No tree match? Ad-hoc, row-level, entity-lookup, or SQL-shaped questions route per the qluent-interpretation skill (slash command /qluent:query): a composed plan first when the query catalog covers the question, else qluent query. KPI movement/RCA questions stay on the trees above.')
+print('Query is the default route for general business and data questions: use /qluent:query, which tries a composed plan when the catalog covers the question and otherwise falls back to qluent query.')
+print('Use /qluent:investigate as the advanced route for explicit KPI movement, RCA, trend, or lever analysis backed by one of the configured trees above.')
 print('On first run, orient the user from this tree metadata and offer one concrete first command. Use qluent whoami/status/suggestions only when available; do not probe unsupported project/status commands.')
 print('After an investigation, offer an RCA report, mix-shift report, or elasticity report through /qluent:visualize before any local HTML fallback.')
 print()
-print('Ask a business performance question or use /qluent:investigate to start, for example /qluent:investigate revenue last month.')
+print('Ask a business or data question or use /qluent:query to start.')
 " 2>/dev/null) || context=""
 
 if [ -n "$context" ]; then
@@ -119,7 +130,7 @@ except Exception:
 if not bases:
     sys.exit(0)
 print(f'[Qluent] Query catalog available: {len(bases)} bases, {len(metrics)} metrics (cached at /tmp/qluent-catalog.json).')
-print('For ad-hoc aggregations, breakdowns and rankings the catalog covers, prefer a composed plan (qluent plan; protocol in the compose-authoring skill) over the NL qluent query -- deterministic and catalog-checked.')
+print('Query is the default workflow. /qluent:query prefers a composed plan when this catalog covers the question, then falls back to the NL qluent query.')
 " 2>/dev/null) || compose_context=""
   elif grep -q 'QUERY_CATALOG_INVALID' "$catalog_err" 2>/dev/null; then
     compose_context='[Qluent] This project has a query_catalog that fails to load (fix it under the Model tab) -- composed plans are unavailable until then; ad-hoc questions fall back to qluent query.'

--- a/plugins/qluent/skills/qluent-interpretation/SKILL.md
+++ b/plugins/qluent/skills/qluent-interpretation/SKILL.md
@@ -33,28 +33,33 @@ client-side before any quantitative call.
 Always pass an explicit `<tree_id>` to every qluent subcommand.
 Always use `--json-output`.
 
-## Ad-hoc query routing
+## Query-first routing
 
-**Trees first, composed plans second, NL query last — the more deterministic
-engine wins ties.**
+**Query is the default workflow. Metric trees are the advanced workflow for
+explicit deterministic KPI analysis. Within queries, composed plans beat the
+NL fallback whenever catalog coverage is complete.**
 
 Route to a metric tree (`/qluent:investigate`, `qluent-analyst` tree workflow)
-when the question is about a KPI's level, movement, trend, drivers, mix, or
-sensitivity AND it maps to a configured tree's root metric, child node, or
-declared dimension in the session catalog.
+when the user explicitly asks for deterministic movement analysis, RCA,
+drivers, trend classification, mix-shift, or sensitivity/levers AND the
+question maps to a configured tree's root metric, child node, or declared
+dimension in the session catalog.
 
-Route away from trees when ANY of these hold:
+Keep the default query workflow when ANY of these hold:
 
-1. **Row/entity level** — the question needs individual records or entities
+1. **General metric question** — the user asks for a value, aggregation,
+   breakdown, ranking, comparison, or change without requesting deterministic
+   tree attribution.
+2. **Row/entity level** — the question needs individual records or entities
    (specific orders, customers, transactions; "list", "show me",
    "top N <records>", "which <entities>").
-2. **No tree coverage** — the metric, dimension, or filter is not declared by
+3. **No tree coverage** — the metric, dimension, or filter is not declared by
    any tree in the catalog, and the unsupported-cut companion-tree fallback
    cannot cover it either.
-3. **SQL-shaped ask** — the question is an arbitrary lookup, count, join, or
+4. **SQL-shaped ask** — the question is an arbitrary lookup, count, join, or
    filter combination rather than a movement explanation ("how many X where
    Y", "average Z per W last month").
-4. **Explicit raw-data ask** — the user wants a table, an export, a
+5. **Explicit raw-data ask** — the user wants a table, an export, a
    spreadsheet, or the SQL itself.
 
 For those questions, prefer a **composed plan** (`qluent plan`, protocol in
@@ -64,10 +69,10 @@ dimensions: composed plans are deterministic and catalog-checked. Use the NL
 `qluent query` only when the catalog lacks the vocabulary, the shape exceeds
 the plan node algebra, or the CLI/backend predates the compose surface.
 
-Trees win ties: if a tree can answer deterministically, use the tree; between
-a composed plan and the NL query, the plan wins. Never decline a data question
-because no tree matches — fall through plan, then NL query. Never re-derive
-numbers a tree investigation already returned.
+Do not require a tree before answering a data question. Fall through to a
+composed plan, then the NL query. Once the user explicitly chooses an
+investigation or asks for tree-specific attribution, keep that workflow
+deterministic and never re-derive its numbers with a query.
 
 Provenance labels differ by engine:
 

--- a/tests/test_protocol_locality.sh
+++ b/tests/test_protocol_locality.sh
@@ -47,7 +47,7 @@ SKILL_ONLY_PHRASES=(
   'cooperative game theory'
   'Do not rerun both JSON and non-JSON'
   'Confidence scores are evidence-coverage heuristics'
-  'Trees win ties'
+  'Do not require a tree before answering a data question'
 )
 
 # Evidence-label list: the four-label vocabulary belongs in the skill. Callers

--- a/tests/test_query_contract.sh
+++ b/tests/test_query_contract.sh
@@ -84,12 +84,17 @@ assert_contains "$QUERY_CMD" 'rm -f /tmp/qluent-query-result.json'
 assert_contains "$ANALYST" 'umask 077'
 
 # 2. The skill owns the canonical routing rule and session-path declaration.
-assert_contains "$SKILL" '## Ad-hoc query routing'
-assert_contains "$SKILL" 'Trees win ties'
+assert_contains "$SKILL" '## Query-first routing'
+assert_contains "$SKILL" 'Query is the default workflow'
 assert_contains "$SKILL" '/tmp/qluent-query-result.json'
 
 # 3. Routing consumers point at the query path.
 assert_contains "$ANALYST" 'qluent query'
+assert_contains "$ANALYST" '  - compose-authoring'
+assert_contains "$ANALYST" 'qluent plan --help'
+assert_contains "$ANALYST" 'qluent catalog --json-output'
+assert_contains "$ANALYST" '/tmp/qluent-plan-result.json'
+assert_contains "$ANALYST" 'composed query (deterministic)'
 assert_contains "$SESSION_START" '/qluent:query'
 
 # 4. Docs advertise the command; visualize declares the renderer boundary.

--- a/tests/test_session_paths.sh
+++ b/tests/test_session_paths.sh
@@ -114,15 +114,18 @@ check_path '/tmp/qluent-catalog.json' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-plan.json' \
+  'plugins/qluent/agents/qluent-analyst.md' \
   'plugins/qluent/commands/query.md' \
   'plugins/qluent/skills/compose-authoring/SKILL.md' \
   'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
   'tests/test_session_paths.sh'
 
 check_path '/tmp/qluent-plan-result.json' \
+  'plugins/qluent/agents/qluent-analyst.md' \
   'plugins/qluent/commands/query.md' \
   'plugins/qluent/skills/compose-authoring/SKILL.md' \
   'plugins/qluent/skills/qluent-interpretation/SKILL.md' \
+  'tests/test_query_contract.sh' \
   'tests/test_session_paths.sh'
 
 echo "session paths tests passed"


### PR DESCRIPTION
## Summary

- make `/qluent:query` the default plugin workflow
- make `/qluent:setup` use effective status and succeed for catalog-only projects
- inject useful query context when zero metric trees are configured
- reserve `/qluent:investigate` for explicit advanced deterministic analysis
- give zero-tree investigations a clear query handoff without mislabeling provenance
- route the analyst through composed plans before the NL-to-SQL fallback
- update plugin documentation and architectural contract tests

## Why

The previous onboarding framed missing metric trees as incomplete setup even when catalog querying was ready. Metric trees should be an optional governed layer for RCA, drivers, trends, mix, and levers—not a prerequisite for getting value from Qluent.

## User impact

New catalog-only customers can begin with project-specific questions immediately. Tree-enabled customers retain deterministic investigation when they explicitly request it.

## Stack

Stacked on #67 (`feat/compose-plan-authoring`).

## Checks

- complete plugin CI contract suite
- `git diff --check`
